### PR TITLE
Add bitcoode parsing support

### DIFF
--- a/src/Bitcode.zig
+++ b/src/Bitcode.zig
@@ -1,0 +1,20 @@
+const Elf = @This();
+
+const std = @import("std");
+const builtin = @import("builtin");
+const assert = std.debug.assert;
+const elf = std.elf;
+const fs = std.fs;
+const log = std.log.scoped(.elf);
+const mem = std.mem;
+
+const Allocator = mem.Allocator;
+const Object = @import("Bitcode/Object.zig");
+const Zld = @import("Zld.zig");
+
+// reference documentation:
+// https://llvm.org/docs/BitCodeFormat.html
+
+pub const base_tag = Zld.Tag.bitcode;
+
+base: Zld,

--- a/src/Bitcode/Object.zig
+++ b/src/Bitcode/Object.zig
@@ -1,0 +1,34 @@
+const Object = @This();
+
+const std = @import("std");
+const assert = std.debug.assert;
+const fs = std.fs;
+const log = std.log.scoped(.elf);
+const math = std.math;
+const mem = std.mem;
+
+const Allocator = mem.Allocator;
+const Bitcode = @import("../Bitcode.zig");
+pub const magic = "BC\xC0\xDE";
+
+file: fs.File,
+name: []const u8,
+file_offset: ?u32 = null,
+
+// Reference for llvm bitcode format:
+// https://llvm.org/docs/BitCodeFormat.html
+
+pub fn deinit(self: *Object, allocator: Allocator) void {
+    _ = self;
+    _ = allocator;
+    // ZAR MODIFICATION:
+    // We manage memory of assigned names ourselves in zar - so
+    // freeing this here for that does not make much sense.
+    // allocator.free(self.name);
+}
+
+pub fn parse(self: *Object, allocator: Allocator, target: std.Target) !void {
+    _ = self;
+    _ = allocator;
+    _ = target;
+}

--- a/src/Elf.zig
+++ b/src/Elf.zig
@@ -314,7 +314,7 @@ fn populateMetadata(self: *Elf) !void {
             .e_shstrndx = 0,
         };
         // Magic
-        mem.copy(u8, header.e_ident[0..4], "\x7fELF");
+        mem.copy(u8, header.e_ident[0..4], Object.magic);
         // Class
         header.e_ident[4] = elf.ELFCLASS64;
         // Endianness

--- a/src/Elf/Object.zig
+++ b/src/Elf/Object.zig
@@ -11,6 +11,7 @@ const mem = std.mem;
 const Allocator = mem.Allocator;
 const Atom = @import("Atom.zig");
 const Elf = @import("../Elf.zig");
+pub const magic = "\x7fELF";
 
 file: fs.File,
 name: []const u8,
@@ -34,7 +35,10 @@ pub fn deinit(self: *Object, allocator: Allocator) void {
     self.relocs.deinit(allocator);
     self.symtab.deinit(allocator);
     self.strtab.deinit(allocator);
-    allocator.free(self.name);
+    // ZAR MODIFICATION:
+    // We manage memory of assigned names ourselves in zar - so
+    // freeing this here for that does not make much sense.
+    // allocator.free(self.name);
 }
 
 pub fn parse(self: *Object, allocator: Allocator, target: std.Target) !void {
@@ -44,8 +48,8 @@ pub fn parse(self: *Object, allocator: Allocator, target: std.Target) !void {
     }
     const header = try reader.readStruct(elf.Elf64_Ehdr);
 
-    if (!mem.eql(u8, header.e_ident[0..4], "\x7fELF")) {
-        log.debug("Invalid ELF magic {s}, expected \x7fELF", .{header.e_ident[0..4]});
+    if (!mem.eql(u8, header.e_ident[0..4], magic)) {
+        log.debug("Invalid ELF magic {s}, expected " ++ magic, .{header.e_ident[0..4]});
         return error.NotObject;
     }
     if (header.e_ident[elf.EI_VERSION] != 1) {

--- a/src/MachO.zig
+++ b/src/MachO.zig
@@ -2264,7 +2264,7 @@ fn addDataInCodeLC(self: *MachO) !void {
         self.data_in_code_cmd_index = @intCast(u16, self.load_commands.items.len);
         try self.load_commands.append(self.base.allocator, .{
             .LinkeditData = .{
-                .cmd = macho.LC_DATA_IN_CODE,
+                .cmd = macho.LC.DATA_IN_CODE,
                 .cmdsize = @sizeOf(macho.linkedit_data_command),
                 .dataoff = 0,
                 .datasize = 0,
@@ -2278,7 +2278,7 @@ fn addCodeSignatureLC(self: *MachO) !void {
     self.code_signature_cmd_index = @intCast(u16, self.load_commands.items.len);
     try self.load_commands.append(self.base.allocator, .{
         .LinkeditData = .{
-            .cmd = macho.LC_CODE_SIGNATURE,
+            .cmd = macho.LC.CODE_SIGNATURE,
             .cmdsize = @sizeOf(macho.linkedit_data_command),
             .dataoff = 0,
             .datasize = 0,
@@ -2294,7 +2294,7 @@ fn addRpathLCs(self: *MachO, rpaths: []const []const u8) !void {
             @sizeOf(u64),
         ));
         var rpath_cmd = commands.emptyGenericCommandWithData(macho.rpath_command{
-            .cmd = macho.LC_RPATH,
+            .cmd = macho.LC.RPATH,
             .cmdsize = cmdsize,
             .path = @sizeOf(macho.rpath_command),
         });
@@ -2551,7 +2551,7 @@ fn populateMetadata(self: *MachO) !void {
         self.dyld_info_cmd_index = @intCast(u16, self.load_commands.items.len);
         try self.load_commands.append(self.base.allocator, .{
             .DyldInfoOnly = .{
-                .cmd = macho.LC_DYLD_INFO_ONLY,
+                .cmd = macho.LC.DYLD_INFO_ONLY,
                 .cmdsize = @sizeOf(macho.dyld_info_command),
                 .rebase_off = 0,
                 .rebase_size = 0,
@@ -2571,7 +2571,7 @@ fn populateMetadata(self: *MachO) !void {
         self.symtab_cmd_index = @intCast(u16, self.load_commands.items.len);
         try self.load_commands.append(self.base.allocator, .{
             .Symtab = .{
-                .cmd = macho.LC_SYMTAB,
+                .cmd = macho.LC.SYMTAB,
                 .cmdsize = @sizeOf(macho.symtab_command),
                 .symoff = 0,
                 .nsyms = 0,
@@ -2585,7 +2585,7 @@ fn populateMetadata(self: *MachO) !void {
         self.dysymtab_cmd_index = @intCast(u16, self.load_commands.items.len);
         try self.load_commands.append(self.base.allocator, .{
             .Dysymtab = .{
-                .cmd = macho.LC_DYSYMTAB,
+                .cmd = macho.LC.DYSYMTAB,
                 .cmdsize = @sizeOf(macho.dysymtab_command),
                 .ilocalsym = 0,
                 .nlocalsym = 0,
@@ -2617,7 +2617,7 @@ fn populateMetadata(self: *MachO) !void {
             @sizeOf(u64),
         ));
         var dylinker_cmd = commands.emptyGenericCommandWithData(macho.dylinker_command{
-            .cmd = macho.LC_LOAD_DYLINKER,
+            .cmd = macho.LC.LOAD_DYLINKER,
             .cmdsize = cmdsize,
             .name = @sizeOf(macho.dylinker_command),
         });
@@ -2631,7 +2631,7 @@ fn populateMetadata(self: *MachO) !void {
         self.main_cmd_index = @intCast(u16, self.load_commands.items.len);
         try self.load_commands.append(self.base.allocator, .{
             .Main = .{
-                .cmd = macho.LC_MAIN,
+                .cmd = macho.LC.MAIN,
                 .cmdsize = @sizeOf(macho.entry_point_command),
                 .entryoff = 0x0,
                 .stacksize = 0,
@@ -2657,7 +2657,7 @@ fn populateMetadata(self: *MachO) !void {
             compat_version.major << 16 | compat_version.minor << 8 | compat_version.patch,
         );
         errdefer dylib_cmd.deinit(self.base.allocator);
-        dylib_cmd.inner.cmd = macho.LC_ID_DYLIB;
+        dylib_cmd.inner.cmd = macho.LC.ID_DYLIB;
         try self.load_commands.append(self.base.allocator, .{ .Dylib = dylib_cmd });
     }
 
@@ -2665,7 +2665,7 @@ fn populateMetadata(self: *MachO) !void {
         self.source_version_cmd_index = @intCast(u16, self.load_commands.items.len);
         try self.load_commands.append(self.base.allocator, .{
             .SourceVersion = .{
-                .cmd = macho.LC_SOURCE_VERSION,
+                .cmd = macho.LC.SOURCE_VERSION,
                 .cmdsize = @sizeOf(macho.source_version_command),
                 .version = 0x0,
             },
@@ -2690,7 +2690,7 @@ fn populateMetadata(self: *MachO) !void {
         const sdk_version = platform_version;
         const is_simulator_abi = self.base.options.target.abi == .simulator;
         var cmd = commands.emptyGenericCommandWithData(macho.build_version_command{
-            .cmd = macho.LC_BUILD_VERSION,
+            .cmd = macho.LC.BUILD_VERSION,
             .cmdsize = cmdsize,
             .platform = switch (self.base.options.target.os.tag) {
                 .macos => macho.PLATFORM_MACOS,
@@ -2716,7 +2716,7 @@ fn populateMetadata(self: *MachO) !void {
     if (self.uuid_cmd_index == null) {
         self.uuid_cmd_index = @intCast(u16, self.load_commands.items.len);
         var uuid_cmd: macho.uuid_command = .{
-            .cmd = macho.LC_UUID,
+            .cmd = macho.LC.UUID,
             .cmdsize = @sizeOf(macho.uuid_command),
             .uuid = undefined,
         };

--- a/src/MachO/Dylib.zig
+++ b/src/MachO/Dylib.zig
@@ -179,16 +179,16 @@ fn readLoadCommands(self: *Dylib, allocator: Allocator, reader: anytype, depende
     while (i < self.header.?.ncmds) : (i += 1) {
         var cmd = try LoadCommand.read(allocator, reader);
         switch (cmd.cmd()) {
-            macho.LC_SYMTAB => {
+            macho.LC.SYMTAB => {
                 self.symtab_cmd_index = i;
             },
-            macho.LC_DYSYMTAB => {
+            macho.LC.DYSYMTAB => {
                 self.dysymtab_cmd_index = i;
             },
-            macho.LC_ID_DYLIB => {
+            macho.LC.ID_DYLIB => {
                 self.id_cmd_index = i;
             },
-            macho.LC_REEXPORT_DYLIB => {
+            macho.LC.REEXPORT_DYLIB => {
                 if (should_lookup_reexports) {
                     // Parse install_name to dependent dylib.
                     var id = try Id.fromLoadCommand(allocator, cmd.Dylib);
@@ -205,7 +205,7 @@ fn readLoadCommands(self: *Dylib, allocator: Allocator, reader: anytype, depende
 
 fn parseId(self: *Dylib, allocator: Allocator) !void {
     const index = self.id_cmd_index orelse {
-        log.debug("no LC_ID_DYLIB load command found; using hard-coded defaults...", .{});
+        log.debug("no LC.ID_DYLIB load command found; using hard-coded defaults...", .{});
         self.id = try Id.default(allocator, self.name);
         return;
     };

--- a/src/MachO/Object.zig
+++ b/src/MachO/Object.zig
@@ -198,7 +198,7 @@ pub fn readLoadCommands(self: *Object, allocator: Allocator, reader: anytype) !v
     while (i < header.ncmds) : (i += 1) {
         var cmd = try LoadCommand.read(allocator, reader);
         switch (cmd.cmd()) {
-            macho.LC_SEGMENT_64 => {
+            macho.LC.SEGMENT_64 => {
                 self.segment_cmd_index = i;
                 var seg = cmd.Segment;
                 for (seg.sections.items) |*sect, j| {
@@ -231,18 +231,18 @@ pub fn readLoadCommands(self: *Object, allocator: Allocator, reader: anytype) !v
 
                 seg.inner.fileoff += offset;
             },
-            macho.LC_SYMTAB => {
+            macho.LC.SYMTAB => {
                 self.symtab_cmd_index = i;
                 cmd.Symtab.symoff += offset;
                 cmd.Symtab.stroff += offset;
             },
-            macho.LC_DYSYMTAB => {
+            macho.LC.DYSYMTAB => {
                 self.dysymtab_cmd_index = i;
             },
-            macho.LC_BUILD_VERSION => {
+            macho.LC.BUILD_VERSION => {
                 self.build_version_cmd_index = i;
             },
-            macho.LC_DATA_IN_CODE => {
+            macho.LC.DATA_IN_CODE => {
                 self.data_in_code_cmd_index = i;
                 cmd.LinkeditData.dataoff += offset;
             },

--- a/src/MachO/commands.zig
+++ b/src/MachO/commands.zig
@@ -57,59 +57,59 @@ pub const LoadCommand = union(enum) {
         var stream = io.fixedBufferStream(buffer);
 
         return switch (header.cmd) {
-            macho.LC_SEGMENT_64 => LoadCommand{
+            macho.LC.SEGMENT_64 => LoadCommand{
                 .Segment = try SegmentCommand.read(allocator, stream.reader()),
             },
-            macho.LC_DYLD_INFO,
-            macho.LC_DYLD_INFO_ONLY,
+            macho.LC.DYLD_INFO,
+            macho.LC.DYLD_INFO_ONLY,
             => LoadCommand{
                 .DyldInfoOnly = try stream.reader().readStruct(macho.dyld_info_command),
             },
-            macho.LC_SYMTAB => LoadCommand{
+            macho.LC.SYMTAB => LoadCommand{
                 .Symtab = try stream.reader().readStruct(macho.symtab_command),
             },
-            macho.LC_DYSYMTAB => LoadCommand{
+            macho.LC.DYSYMTAB => LoadCommand{
                 .Dysymtab = try stream.reader().readStruct(macho.dysymtab_command),
             },
-            macho.LC_ID_DYLINKER,
-            macho.LC_LOAD_DYLINKER,
-            macho.LC_DYLD_ENVIRONMENT,
+            macho.LC.ID_DYLINKER,
+            macho.LC.LOAD_DYLINKER,
+            macho.LC.DYLD_ENVIRONMENT,
             => LoadCommand{
                 .Dylinker = try GenericCommandWithData(macho.dylinker_command).read(allocator, stream.reader()),
             },
-            macho.LC_ID_DYLIB,
-            macho.LC_LOAD_WEAK_DYLIB,
-            macho.LC_LOAD_DYLIB,
-            macho.LC_REEXPORT_DYLIB,
+            macho.LC.ID_DYLIB,
+            macho.LC.LOAD_WEAK_DYLIB,
+            macho.LC.LOAD_DYLIB,
+            macho.LC.REEXPORT_DYLIB,
             => LoadCommand{
                 .Dylib = try GenericCommandWithData(macho.dylib_command).read(allocator, stream.reader()),
             },
-            macho.LC_MAIN => LoadCommand{
+            macho.LC.MAIN => LoadCommand{
                 .Main = try stream.reader().readStruct(macho.entry_point_command),
             },
-            macho.LC_VERSION_MIN_MACOSX,
-            macho.LC_VERSION_MIN_IPHONEOS,
-            macho.LC_VERSION_MIN_WATCHOS,
-            macho.LC_VERSION_MIN_TVOS,
+            macho.LC.VERSION_MIN_MACOSX,
+            macho.LC.VERSION_MIN_IPHONEOS,
+            macho.LC.VERSION_MIN_WATCHOS,
+            macho.LC.VERSION_MIN_TVOS,
             => LoadCommand{
                 .VersionMin = try stream.reader().readStruct(macho.version_min_command),
             },
-            macho.LC_SOURCE_VERSION => LoadCommand{
+            macho.LC.SOURCE_VERSION => LoadCommand{
                 .SourceVersion = try stream.reader().readStruct(macho.source_version_command),
             },
-            macho.LC_BUILD_VERSION => LoadCommand{
+            macho.LC.BUILD_VERSION => LoadCommand{
                 .BuildVersion = try GenericCommandWithData(macho.build_version_command).read(allocator, stream.reader()),
             },
-            macho.LC_UUID => LoadCommand{
+            macho.LC.UUID => LoadCommand{
                 .Uuid = try stream.reader().readStruct(macho.uuid_command),
             },
-            macho.LC_FUNCTION_STARTS,
-            macho.LC_DATA_IN_CODE,
-            macho.LC_CODE_SIGNATURE,
+            macho.LC.FUNCTION_STARTS,
+            macho.LC.DATA_IN_CODE,
+            macho.LC.CODE_SIGNATURE,
             => LoadCommand{
                 .LinkeditData = try stream.reader().readStruct(macho.linkedit_data_command),
             },
-            macho.LC_RPATH => LoadCommand{
+            macho.LC.RPATH => LoadCommand{
                 .Rpath = try GenericCommandWithData(macho.rpath_command).read(allocator, stream.reader()),
             },
             else => LoadCommand{
@@ -137,7 +137,7 @@ pub const LoadCommand = union(enum) {
         };
     }
 
-    pub fn cmd(self: LoadCommand) u32 {
+    pub fn cmd(self: LoadCommand) macho.LC {
         return switch (self) {
             .DyldInfoOnly => |x| x.cmd,
             .Symtab => |x| x.cmd,
@@ -231,7 +231,7 @@ pub const SegmentCommand = struct {
     pub fn empty(comptime segname: []const u8, opts: SegmentOptions) SegmentCommand {
         return .{
             .inner = .{
-                .cmd = macho.LC_SEGMENT_64,
+                .cmd = macho.LC.SEGMENT_64,
                 .cmdsize = opts.cmdsize,
                 .segname = makeStaticString(segname),
                 .vmaddr = opts.vmaddr,
@@ -377,7 +377,7 @@ pub fn createLoadDylibCommand(
     ));
 
     var dylib_cmd = emptyGenericCommandWithData(macho.dylib_command{
-        .cmd = macho.LC_LOAD_DYLIB,
+        .cmd = macho.LC.LOAD_DYLIB,
         .cmdsize = cmdsize,
         .dylib = .{
             .name = @sizeOf(macho.dylib_command),
@@ -481,7 +481,7 @@ test "read-write segment command" {
     };
     var cmd = SegmentCommand{
         .inner = .{
-            .cmd = macho.LC_SEGMENT_64,
+            .cmd = macho.LC.SEGMENT_64,
             .cmdsize = 152,
             .segname = makeStaticString("__TEXT"),
             .vmaddr = 4294967296,
@@ -528,7 +528,7 @@ test "read-write generic command with data" {
     };
     var cmd = GenericCommandWithData(macho.dylib_command){
         .inner = .{
-            .cmd = macho.LC_LOAD_DYLIB,
+            .cmd = macho.LC.LOAD_DYLIB,
             .cmdsize = 32,
             .dylib = .{
                 .name = 24,
@@ -563,7 +563,7 @@ test "read-write C struct command" {
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // stacksize
     };
     const cmd = .{
-        .cmd = macho.LC_MAIN,
+        .cmd = macho.LC.MAIN,
         .cmdsize = 24,
         .entryoff = 16644,
         .stacksize = 0,

--- a/src/Zld.zig
+++ b/src/Zld.zig
@@ -20,6 +20,7 @@ pub const Tag = enum {
     coff,
     elf,
     macho,
+    bitcode,
 };
 
 pub const Emit = struct {


### PR DESCRIPTION
I'm currently working on adding [bitcode](https://llvm.org/docs/BitCodeFormat.html) parsing support in https://github.com/moosichu/zar,  as milestones are reached I will update this branch to mirror those changes so they can be more easily tracked against zld.

For now I will focus purely on the needs of the archiver (as you can see, there are some unrelated changes in this PR), with the intent of cleaning things up once those needs have been met. 