### PR TITLE
macho: improve linking speed, reduce memory usage

### DIFF
--- a/src/Coff/Options.zig
+++ b/src/Coff/Options.zig
@@ -12,7 +12,7 @@ const Coff = @import("../Coff.zig");
 const Zld = @import("../Zld.zig");
 
 const usage =
-    \\Usage: link-zld [files...]
+    \\Usage: {s} [files...]
     \\
     \\General Options:
     \\-l[name]                      Specify library to link against
@@ -31,7 +31,7 @@ lib_dirs: []const []const u8,
 
 pub fn parseArgs(arena: Allocator, ctx: Zld.MainCtx) !Options {
     if (ctx.args.len == 0) {
-        ctx.printSuccess("{s}", .{usage});
+        ctx.printSuccess(usage, .{ctx.cmd});
     }
 
     var positionals = std.ArrayList(Zld.LinkObject).init(arena);
@@ -54,7 +54,7 @@ pub fn parseArgs(arena: Allocator, ctx: Zld.MainCtx) !Options {
 
     while (args_iter.next()) |arg| {
         if (mem.eql(u8, arg, "--help") or mem.eql(u8, arg, "-h")) {
-            ctx.printSuccess("{s}", .{usage});
+            ctx.printSuccess(usage, .{ctx.cmd});
         } else if (mem.eql(u8, arg, "--debug-log")) {
             const scope = args_iter.next() orelse ctx.printFailure("Expected log scope after {s}", .{arg});
             try ctx.log_scopes.append(scope);

--- a/src/Elf/Options.zig
+++ b/src/Elf/Options.zig
@@ -12,7 +12,7 @@ const Elf = @import("../Elf.zig");
 const Zld = @import("../Zld.zig");
 
 const usage =
-    \\Usage: ld.zld [files...]
+    \\Usage: {s} [files...]
     \\
     \\General Options:
     \\--entry=[name]                Set name of the entry point symbol
@@ -44,7 +44,7 @@ gc_sections: bool = false,
 
 pub fn parseArgs(arena: Allocator, ctx: Zld.MainCtx) !Options {
     if (ctx.args.len == 0) {
-        ctx.printSuccess("{s}", .{usage});
+        ctx.printSuccess(usage, .{ctx.cmd});
     }
 
     var positionals = std.ArrayList(Zld.LinkObject).init(arena);
@@ -72,7 +72,7 @@ pub fn parseArgs(arena: Allocator, ctx: Zld.MainCtx) !Options {
 
     while (args_iter.next()) |arg| {
         if (mem.eql(u8, arg, "--help") or mem.eql(u8, arg, "-h")) {
-            ctx.printSuccess("{s}", .{usage});
+            ctx.printSuccess(usage, .{ctx.cmd});
         } else if (mem.eql(u8, arg, "--debug-log")) {
             const scope = args_iter.next() orelse ctx.printFailure("Expected log scope after {s}", .{arg});
             try ctx.log_scopes.append(scope);

--- a/src/MachO.zig
+++ b/src/MachO.zig
@@ -2022,7 +2022,7 @@ fn createTentativeDefAtoms(self: *MachO) !void {
         const sym = self.getSymbolPtr(global);
         if (!sym.tentative()) continue;
 
-        log.debug("creating tentative definition for ATOM(%{d}, '{s}') in object({d})", .{
+        log.debug("creating tentative definition for ATOM(%{d}, '{s}') in object({?})", .{
             global.sym_index, self.getSymbolName(global), global.file,
         });
 
@@ -2919,7 +2919,7 @@ fn writeAtoms(self: *MachO) !void {
                 break :blk math.cast(usize, size) orelse return error.Overflow;
             } else 0;
 
-            log.debug("  (adding ATOM(%{d}, '{s}') from object({d}) to buffer)", .{
+            log.debug("  (adding ATOM(%{d}, '{s}') from object({?}) to buffer)", .{
                 atom.sym_index,
                 atom.getName(self),
                 atom.file,
@@ -4328,7 +4328,7 @@ fn logAtoms(self: *MachO) void {
 pub fn logAtom(self: *MachO, atom: *const Atom) void {
     const sym = atom.getSymbol(self);
     const sym_name = atom.getName(self);
-    log.debug("  ATOM(%{d}, '{s}') @ {x} (sizeof({x}), alignof({x})) in object({d}) in sect({d})", .{
+    log.debug("  ATOM(%{d}, '{s}') @ {x} (sizeof({x}), alignof({x})) in object({?}) in sect({d})", .{
         atom.sym_index,
         sym_name,
         sym.n_value,

--- a/src/MachO.zig
+++ b/src/MachO.zig
@@ -4056,6 +4056,7 @@ pub fn generateSymbolStabs(
 
     const gpa = self.base.allocator;
     var debug_info = try object.parseDwarfInfo();
+    defer debug_info.deinit(gpa);
     try dwarf.openDwarfDebugInfo(&debug_info, gpa);
 
     // We assume there is only one CU.

--- a/src/MachO/Atom.zig
+++ b/src/MachO/Atom.zig
@@ -422,8 +422,9 @@ fn addPtrBindingOrRebase(
         });
     } else {
         const source_sym = self.getSymbol(context.macho_file);
-        const sect = context.macho_file.sections.items[source_sym.n_sect - 1];
-        const seg_id = context.macho_file.segments_table.get(source_sym.n_sect - 1).?;
+        const entry = context.macho_file.sections.get(source_sym.n_sect - 1);
+        const sect = entry.section;
+        const seg_id = entry.segment_index;
         const sect_type = sect.type_();
 
         const should_rebase = rebase: {
@@ -525,7 +526,7 @@ pub fn resolveRelocs(self: *Atom, macho_file: *MachO) !void {
         };
         const is_tlv = is_tlv: {
             const source_sym = self.getSymbol(macho_file);
-            const sect = macho_file.sections.items[source_sym.n_sect - 1];
+            const sect = macho_file.sections.items(.section)[source_sym.n_sect - 1];
             break :is_tlv sect.type_() == macho.S_THREAD_LOCAL_VARIABLES;
         };
         const target_addr = blk: {
@@ -567,7 +568,7 @@ pub fn resolveRelocs(self: *Atom, macho_file: *MachO) !void {
                         return error.FailedToResolveRelocationTarget;
                     }
                 };
-                break :base_address macho_file.sections.items[sect_id].addr;
+                break :base_address macho_file.sections.items(.section)[sect_id].addr;
             } else 0;
             break :blk target_sym.n_value - base_address;
         };

--- a/src/MachO/Atom.zig
+++ b/src/MachO/Atom.zig
@@ -423,7 +423,7 @@ fn addPtrBindingOrRebase(
     } else {
         const source_sym = self.getSymbol(context.macho_file);
         const sect = context.macho_file.sections.items[source_sym.n_sect - 1];
-        const seg_id = context.macho_file.getSegmentId(sect);
+        const seg_id = context.macho_file.segments_table.get(source_sym.n_sect - 1).?;
         const sect_type = sect.type_();
 
         const should_rebase = rebase: {

--- a/src/MachO/Atom.zig
+++ b/src/MachO/Atom.zig
@@ -205,7 +205,7 @@ pub fn parseRelocs(self: *Atom, relocs: []const macho.relocation_info, context: 
                             else => {
                                 log.err("unexpected relocation type after ARM64_RELOC_ADDEND", .{});
                                 log.err("  expected ARM64_RELOC_PAGE21 or ARM64_RELOC_PAGEOFF12", .{});
-                                log.err("  found {s}", .{next});
+                                log.err("  found {s}", .{@tagName(next)});
                                 return error.UnexpectedRelocationType;
                             },
                         }
@@ -244,7 +244,9 @@ pub fn parseRelocs(self: *Atom, relocs: []const macho.relocation_info, context: 
                     else => {
                         log.err("unexpected relocation type after ARM64_RELOC_ADDEND", .{});
                         log.err("  expected ARM64_RELOC_UNSIGNED", .{});
-                        log.err("  found {s}", .{@intToEnum(macho.reloc_type_arm64, relocs[i + 1].r_type)});
+                        log.err("  found {s}", .{
+                            @tagName(@intToEnum(macho.reloc_type_arm64, relocs[i + 1].r_type)),
+                        });
                         return error.UnexpectedRelocationType;
                     },
                 },
@@ -253,7 +255,9 @@ pub fn parseRelocs(self: *Atom, relocs: []const macho.relocation_info, context: 
                     else => {
                         log.err("unexpected relocation type after X86_64_RELOC_ADDEND", .{});
                         log.err("  expected X86_64_RELOC_UNSIGNED", .{});
-                        log.err("  found {s}", .{@intToEnum(macho.reloc_type_x86_64, relocs[i + 1].r_type)});
+                        log.err("  found {s}", .{
+                            @tagName(@intToEnum(macho.reloc_type_x86_64, relocs[i + 1].r_type)),
+                        });
                         return error.UnexpectedRelocationType;
                     },
                 },
@@ -497,7 +501,7 @@ pub fn resolveRelocs(self: *Atom, macho_file: *MachO) !void {
         const arch = macho_file.options.target.cpu_arch.?;
         switch (arch) {
             .aarch64 => {
-                log.debug("  RELA({s}) @ {x} => %{d} in object({d})", .{
+                log.debug("  RELA({s}) @ {x} => %{d} in object({?})", .{
                     @tagName(@intToEnum(macho.reloc_type_arm64, rel.@"type")),
                     rel.offset,
                     rel.target.sym_index,
@@ -505,7 +509,7 @@ pub fn resolveRelocs(self: *Atom, macho_file: *MachO) !void {
                 });
             },
             .x86_64 => {
-                log.debug("  RELA({s}) @ {x} => %{d} in object({d})", .{
+                log.debug("  RELA({s}) @ {x} => %{d} in object({?})", .{
                     @tagName(@intToEnum(macho.reloc_type_x86_64, rel.@"type")),
                     rel.offset,
                     rel.target.sym_index,
@@ -535,7 +539,7 @@ pub fn resolveRelocs(self: *Atom, macho_file: *MachO) !void {
                 log.debug("    | atomless target '{s}'", .{target_name});
                 break :blk atomless_sym.n_value;
             };
-            log.debug("    | target ATOM(%{d}, '{s}') in object({d})", .{
+            log.debug("    | target ATOM(%{d}, '{s}') in object({?})", .{
                 target_atom.sym_index,
                 target_atom.getName(macho_file),
                 target_atom.file,

--- a/src/MachO/Atom.zig
+++ b/src/MachO/Atom.zig
@@ -422,10 +422,10 @@ fn addPtrBindingOrRebase(
         });
     } else {
         const source_sym = self.getSymbol(context.macho_file);
-        const entry = context.macho_file.sections.get(source_sym.n_sect - 1);
-        const sect = entry.section;
-        const seg_id = entry.segment_index;
-        const sect_type = sect.type_();
+        const section = context.macho_file.sections.get(source_sym.n_sect - 1);
+        const header = section.header;
+        const segment_index = section.segment_index;
+        const sect_type = header.type_();
 
         const should_rebase = rebase: {
             if (rel.r_length != 3) break :rebase false;
@@ -434,12 +434,12 @@ fn addPtrBindingOrRebase(
             // that the segment is writable should be enough here.
             const is_right_segment = blk: {
                 if (context.macho_file.data_segment_cmd_index) |idx| {
-                    if (seg_id == idx) {
+                    if (segment_index == idx) {
                         break :blk true;
                     }
                 }
                 if (context.macho_file.data_const_segment_cmd_index) |idx| {
-                    if (seg_id == idx) {
+                    if (segment_index == idx) {
                         break :blk true;
                     }
                 }
@@ -526,8 +526,8 @@ pub fn resolveRelocs(self: *Atom, macho_file: *MachO) !void {
         };
         const is_tlv = is_tlv: {
             const source_sym = self.getSymbol(macho_file);
-            const sect = macho_file.sections.items(.section)[source_sym.n_sect - 1];
-            break :is_tlv sect.type_() == macho.S_THREAD_LOCAL_VARIABLES;
+            const header = macho_file.sections.items(.header)[source_sym.n_sect - 1];
+            break :is_tlv header.type_() == macho.S_THREAD_LOCAL_VARIABLES;
         };
         const target_addr = blk: {
             const target_atom = rel.getTargetAtom(macho_file) orelse {
@@ -568,7 +568,7 @@ pub fn resolveRelocs(self: *Atom, macho_file: *MachO) !void {
                         return error.FailedToResolveRelocationTarget;
                     }
                 };
-                break :base_address macho_file.sections.items(.section)[sect_id].addr;
+                break :base_address macho_file.sections.items(.header)[sect_id].addr;
             } else 0;
             break :blk target_sym.n_value - base_address;
         };

--- a/src/MachO/CodeSignature.zig
+++ b/src/MachO/CodeSignature.zig
@@ -253,7 +253,7 @@ pub const WriteOpts = struct {
     file: fs.File,
     exec_seg_base: u64,
     exec_seg_limit: u64,
-    code_sig_cmd: macho.linkedit_data_command,
+    file_size: u32,
     output_mode: Zld.OutputMode,
 };
 
@@ -275,10 +275,9 @@ pub fn writeAdhocSignature(
     self.code_directory.inner.execSegBase = opts.exec_seg_base;
     self.code_directory.inner.execSegLimit = opts.exec_seg_limit;
     self.code_directory.inner.execSegFlags = if (opts.output_mode == .exe) macho.CS_EXECSEG_MAIN_BINARY else 0;
-    const file_size = opts.code_sig_cmd.dataoff;
-    self.code_directory.inner.codeLimit = file_size;
+    self.code_directory.inner.codeLimit = opts.file_size;
 
-    const total_pages = mem.alignForward(file_size, self.page_size) / self.page_size;
+    const total_pages = mem.alignForward(opts.file_size, self.page_size) / self.page_size;
 
     var buffer = try allocator.alloc(u8, self.page_size);
     defer allocator.free(buffer);
@@ -290,7 +289,10 @@ pub fn writeAdhocSignature(
     var i: usize = 0;
     while (i < total_pages) : (i += 1) {
         const fstart = i * self.page_size;
-        const fsize = if (fstart + self.page_size > file_size) file_size - fstart else self.page_size;
+        const fsize = if (fstart + self.page_size > opts.file_size)
+            opts.file_size - fstart
+        else
+            self.page_size;
         const len = try opts.file.preadAll(buffer, fstart);
         assert(fsize <= len);
 

--- a/src/MachO/Dylib.zig
+++ b/src/MachO/Dylib.zig
@@ -144,7 +144,10 @@ pub fn parseFromBinary(
     const this_arch: std.Target.Cpu.Arch = try fat.decodeArch(header.cputype, true);
 
     if (this_arch != cpu_arch) {
-        log.err("mismatched cpu architecture: expected {s}, found {s}", .{ cpu_arch, this_arch });
+        log.err("mismatched cpu architecture: expected {s}, found {s}", .{
+            @tagName(cpu_arch),
+            @tagName(this_arch),
+        });
         return error.MismatchedCpuArchitecture;
     }
 

--- a/src/MachO/Object.zig
+++ b/src/MachO/Object.zig
@@ -274,8 +274,8 @@ pub fn splitIntoAtoms(self: *Object, macho_file: *MachO, object_id: u32) !void {
 
         log.debug("  output sect({d}, '{s},{s}')", .{
             match + 1,
-            macho_file.sections.items(.section)[match].segName(),
-            macho_file.sections.items(.section)[match].sectName(),
+            macho_file.sections.items(.header)[match].segName(),
+            macho_file.sections.items(.header)[match].sectName(),
         });
 
         const cpu_arch = macho_file.options.target.cpu_arch.?;
@@ -473,8 +473,8 @@ fn createAtomFromSubsection(
         sym_index,
         self.getString(sym.n_strx),
         match + 1,
-        macho_file.sections.items(.section)[match].segName(),
-        macho_file.sections.items(.section)[match].sectName(),
+        macho_file.sections.items(.header)[match].segName(),
+        macho_file.sections.items(.header)[match].sectName(),
         object_id,
     });
 

--- a/src/MachO/Object.zig
+++ b/src/MachO/Object.zig
@@ -274,8 +274,8 @@ pub fn splitIntoAtoms(self: *Object, macho_file: *MachO, object_id: u32) !void {
 
         log.debug("  output sect({d}, '{s},{s}')", .{
             match + 1,
-            macho_file.sections.items[match].segName(),
-            macho_file.sections.items[match].sectName(),
+            macho_file.sections.items(.section)[match].segName(),
+            macho_file.sections.items(.section)[match].sectName(),
         });
 
         const cpu_arch = macho_file.options.target.cpu_arch.?;
@@ -473,8 +473,8 @@ fn createAtomFromSubsection(
         sym_index,
         self.getString(sym.n_strx),
         match + 1,
-        macho_file.sections.items[match].segName(),
-        macho_file.sections.items[match].sectName(),
+        macho_file.sections.items(.section)[match].segName(),
+        macho_file.sections.items(.section)[match].sectName(),
         object_id,
     });
 

--- a/src/MachO/Object.zig
+++ b/src/MachO/Object.zig
@@ -83,7 +83,10 @@ pub fn parse(self: *Object, allocator: Allocator, cpu_arch: std.Target.Cpu.Arch)
         },
     };
     if (this_arch != cpu_arch) {
-        log.err("mismatched cpu architecture: expected {s}, found {s}", .{ cpu_arch, this_arch });
+        log.err("mismatched cpu architecture: expected {s}, found {s}", .{
+            @tagName(cpu_arch),
+            @tagName(this_arch),
+        });
         return error.MismatchedCpuArchitecture;
     }
 

--- a/src/MachO/Options.zig
+++ b/src/MachO/Options.zig
@@ -18,7 +18,7 @@ pub const SearchStrategy = enum {
 };
 
 const usage =
-    \\Usage: ld64.zld [files...]
+    \\Usage: {s} [files...]
     \\
     \\General Options:
     \\
@@ -158,7 +158,7 @@ allow_undef: bool = false,
 
 pub fn parseArgs(arena: Allocator, ctx: Zld.MainCtx) !Options {
     if (ctx.args.len == 0) {
-        ctx.printSuccess("{s}", .{usage});
+        ctx.printSuccess(usage, .{ctx.cmd});
     }
 
     var positionals = std.ArrayList(Zld.LinkObject).init(arena);
@@ -212,16 +212,12 @@ pub fn parseArgs(arena: Allocator, ctx: Zld.MainCtx) !Options {
 
     while (args_iter.next()) |arg| {
         if (mem.eql(u8, arg, "--help") or mem.eql(u8, arg, "-h")) {
-            ctx.printSuccess("{s}", .{usage});
+            ctx.printSuccess(usage, .{ctx.cmd});
         } else if (mem.eql(u8, arg, "--debug-log")) {
             const scope = args_iter.next() orelse ctx.printFailure("Expected log scope after {s}", .{arg});
             try ctx.log_scopes.append(scope);
         } else if (mem.eql(u8, arg, "-syslibroot")) {
             syslibroot = args_iter.next() orelse ctx.printFailure("Expected path after {s}", .{arg});
-        } else if (mem.startsWith(u8, arg, "-l")) {
-            try libs.put(arg[2..], .{});
-        } else if (mem.startsWith(u8, arg, "-L")) {
-            try lib_dirs.append(arg[2..]);
         } else if (mem.eql(u8, arg, "-framework") or mem.eql(u8, arg, "-weak_framework")) {
             const name = args_iter.next() orelse ctx.printFailure("Expected framework name after {s}", .{arg});
             try frameworks.put(name, .{});
@@ -416,6 +412,16 @@ pub fn parseArgs(arena: Allocator, ctx: Zld.MainCtx) !Options {
             } else {
                 ctx.printFailure("Unknown option -undefined {s}", .{treatment});
             }
+        } else if (mem.eql(u8, arg, "-lto_library")) {
+            const lto_lib = args_iter.next() orelse
+                ctx.printFailure("Expected path after {s}", .{arg});
+            ctx.printFailure("TODO unimplemented -lto_library {s} option", .{lto_lib});
+        } else if (mem.eql(u8, arg, "-demangle")) {
+            ctx.printFailure("TODO unimplemented -demangle option", .{});
+        } else if (mem.startsWith(u8, arg, "-l")) {
+            try libs.put(arg[2..], .{});
+        } else if (mem.startsWith(u8, arg, "-L")) {
+            try lib_dirs.append(arg[2..]);
         } else {
             try positionals.append(.{
                 .path = arg,

--- a/src/MachO/dead_strip.zig
+++ b/src/MachO/dead_strip.zig
@@ -25,7 +25,7 @@ pub fn gcAtoms(macho_file: *MachO) !void {
 }
 
 fn removeAtomFromSection(atom: *Atom, match: u8, macho_file: *MachO) void {
-    const sect = &macho_file.sections.items[match];
+    const sect = &macho_file.sections.items(.section)[match];
 
     // If we want to enable GC for incremental codepath, we need to take into
     // account any padding that might have been left here.
@@ -264,7 +264,7 @@ fn prune(arena: Allocator, alive: std.AutoHashMap(*Atom, void), macho_file: *Mac
     var gc_sections_it = gc_sections.iterator();
     while (gc_sections_it.next()) |entry| {
         const match = entry.key_ptr.*;
-        const sect = &macho_file.sections.items[match];
+        const sect = &macho_file.sections.items(.section)[match];
         if (sect.size == 0) continue; // Pruning happens automatically in next step.
 
         sect.@"align" = 0;

--- a/src/MachO/dead_strip.zig
+++ b/src/MachO/dead_strip.zig
@@ -179,7 +179,7 @@ fn prune(arena: Allocator, alive: std.AutoHashMap(*Atom, void), macho_file: *Mac
         loop = false;
 
         for (macho_file.objects.items) |object| {
-            for (object.getSourceSymtab()) |_, source_index| {
+            for (object.in_symtab) |_, source_index| {
                 const atom = object.getAtomForSymbol(@intCast(u32, source_index)) orelse continue;
                 if (alive.contains(atom)) continue;
 

--- a/src/MachO/fat.zig
+++ b/src/MachO/fat.zig
@@ -47,7 +47,9 @@ pub fn getLibraryOffset(reader: anytype, cpu_arch: std.Target.Cpu.Arch) !u64 {
             return fat_arch.offset;
         }
     } else {
-        log.err("Could not find matching cpu architecture in fat library: expected {s}", .{cpu_arch});
+        log.err("Could not find matching cpu architecture in fat library: expected {s}", .{
+            @tagName(cpu_arch),
+        });
         return error.MismatchedCpuArchitecture;
     }
 }

--- a/src/Zld.zig
+++ b/src/Zld.zig
@@ -114,7 +114,7 @@ pub fn flush(base: *Zld) !void {
 fn closeFiles(base: *const Zld) void {
     switch (base.tag) {
         .elf => @fieldParentPtr(Elf, "base", base).closeFiles(),
-        .macho => {},
+        .macho => @fieldParentPtr(MachO, "base", base).closeFiles(),
         .coff => @fieldParentPtr(Coff, "base", base).closeFiles(),
     }
     base.file.close();

--- a/src/Zld.zig
+++ b/src/Zld.zig
@@ -113,7 +113,7 @@ pub fn flush(base: *Zld) !void {
 fn closeFiles(base: *const Zld) void {
     switch (base.tag) {
         .elf => @fieldParentPtr(Elf, "base", base).closeFiles(),
-        .macho => @fieldParentPtr(MachO, "base", base).closeFiles(),
+        .macho => {},
         .coff => @fieldParentPtr(Coff, "base", base).closeFiles(),
     }
     base.file.close();

--- a/src/Zld.zig
+++ b/src/Zld.zig
@@ -50,6 +50,7 @@ pub const Options = union {
 
 pub const MainCtx = struct {
     gpa: Allocator,
+    cmd: []const u8,
     args: []const []const u8,
     log_scopes: *std.ArrayList([]const u8),
 

--- a/src/mm.zig
+++ b/src/mm.zig
@@ -1,0 +1,56 @@
+const std = @import("std");
+const assert = std.debug.assert;
+const macho = std.macho;
+
+pub const LoadCommandIterator = struct {
+    ncmds: usize,
+    buffer: []align(@alignOf(u64)) const u8,
+    index: usize = 0,
+
+    pub const LoadCommand = struct {
+        hdr: macho.load_command,
+        data: []const u8,
+
+        pub fn cmd(lc: LoadCommand) macho.LC {
+            return lc.hdr.cmd;
+        }
+
+        pub fn cmdsize(lc: LoadCommand) u32 {
+            return lc.hdr.cmdsize;
+        }
+
+        pub fn cast(lc: LoadCommand, comptime Cmd: type) ?Cmd {
+            if (lc.data.len < @sizeOf(Cmd)) return null;
+            return @ptrCast(*const Cmd, @alignCast(@alignOf(Cmd), &lc.data[0])).*;
+        }
+
+        /// Asserts LoadCommand is of type macho.segment_command_64.
+        pub fn getSections(lc: LoadCommand) []const macho.section_64 {
+            const segment = lc.cast(macho.segment_command_64).?;
+            const data = lc.data[@sizeOf(macho.segment_command_64)..];
+            const sections = @ptrCast(
+                [*]const macho.section_64,
+                @alignCast(@alignOf(macho.section_64), &data[0]),
+            )[0..segment.nsects];
+            return sections;
+        }
+    };
+
+    pub fn next(it: *LoadCommandIterator) ?LoadCommand {
+        if (it.index >= it.ncmds) return null;
+
+        const hdr = @ptrCast(
+            *const macho.load_command,
+            @alignCast(@alignOf(macho.load_command), &it.buffer[0]),
+        ).*;
+        const cmd = LoadCommand{
+            .hdr = hdr,
+            .data = it.buffer[0..hdr.cmdsize],
+        };
+
+        it.buffer = it.buffer[hdr.cmdsize..];
+        it.index += 1;
+
+        return cmd;
+    }
+};

--- a/src/mm.zig
+++ b/src/mm.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const assert = std.debug.assert;
 const macho = std.macho;
+const mem = std.mem;
 
 pub const LoadCommandIterator = struct {
     ncmds: usize,
@@ -33,6 +34,13 @@ pub const LoadCommandIterator = struct {
                 @alignCast(@alignOf(macho.section_64), &data[0]),
             )[0..segment.nsects];
             return sections;
+        }
+
+        /// Asserts LoadCommand is of type macho.dylib_command.
+        pub fn getDylibPathName(lc: LoadCommand) []const u8 {
+            const dylib = lc.cast(macho.dylib_command).?;
+            const data = lc.data[dylib.dylib.name..];
+            return mem.sliceTo(data, 0);
         }
     };
 


### PR DESCRIPTION
Still more to do, but here's an example improvement of linking `redis-server` with standalone `zld` vs Apple's `ld64` (no `-dead_strip` though!):

<img width="1728" alt="Screenshot 2022-07-31 at 08 31 56" src="https://user-images.githubusercontent.com/1519747/182013340-28628bf7-e6cf-4212-8ba3-32f4643333ee.png">
