### PR TITLE
elf: simplify like macho linker

### DIFF
--- a/src/Elf.zig
+++ b/src/Elf.zig
@@ -482,10 +482,7 @@ fn populateMetadata(self: *Elf) !void {
     }
 }
 
-pub fn getMatchingSection(self: *Elf, object_id: u16, sect_id: u16) !?u16 {
-    const object = self.objects.items[object_id];
-    const shdr = object.getShdrs()[sect_id];
-    const shdr_name = object.getShString(shdr.sh_name);
+pub fn getOutputSection(self: *Elf, shdr: elf.Elf64_Shdr, shdr_name: []const u8) !?u16 {
     const flags = shdr.sh_flags;
     const res: ?u16 = blk: {
         if (flags & elf.SHF_EXCLUDE != 0) break :blk null;
@@ -653,7 +650,7 @@ pub fn getMatchingSection(self: *Elf, object_id: u16, sect_id: u16) !?u16 {
             }
 
             log.debug("TODO non-alloc sections", .{});
-            log.debug("  {s} => {}", .{ object.getShString(shdr.sh_name), shdr });
+            log.debug("  {s} => {}", .{ shdr_name, shdr });
             break :blk null;
         }
         if (flags & elf.SHF_EXECINSTR != 0) {

--- a/src/Elf.zig
+++ b/src/Elf.zig
@@ -249,7 +249,7 @@ pub fn flush(self: *Elf) !void {
     }
 
     for (self.objects.items) |*object, object_id| {
-        try object.parseIntoAtoms(self.base.allocator, @intCast(u16, object_id), self);
+        try object.splitIntoAtoms(self.base.allocator, @intCast(u16, object_id), self);
     }
 
     if (self.options.gc_sections) {
@@ -484,7 +484,7 @@ fn populateMetadata(self: *Elf) !void {
 
 pub fn getMatchingSection(self: *Elf, object_id: u16, sect_id: u16) !?u16 {
     const object = self.objects.items[object_id];
-    const shdr = object.getSourceShdr(sect_id);
+    const shdr = object.getShdrs()[sect_id];
     const shdr_name = object.getShString(shdr.sh_name);
     const flags = shdr.sh_flags;
     const res: ?u16 = blk: {

--- a/src/Elf/Archive.zig
+++ b/src/Elf/Archive.zig
@@ -91,8 +91,7 @@ pub fn deinit(self: *Archive, allocator: Allocator) void {
     allocator.free(self.name);
 }
 
-pub fn parse(self: *Archive, allocator: Allocator) !void {
-    const reader = self.file.reader();
+pub fn parse(self: *Archive, allocator: Allocator, reader: anytype) !void {
     const magic = try reader.readBytesNoEof(SARMAG);
     if (!mem.eql(u8, &magic, ARMAG)) {
         log.debug("invalid magic: expected '{s}', found '{s}'", .{ ARMAG, magic });
@@ -194,14 +193,19 @@ pub fn parseObject(self: Archive, allocator: Allocator, cpu_arch: std.Target.Cpu
         const path = try std.os.realpath(self.name, &buffer);
         break :blk try std.fmt.allocPrint(allocator, "{s}({s})", .{ path, object_name });
     };
+    const object_size = try hdr.size();
+    const data = try allocator.allocWithOptions(u8, object_size, @alignOf(u64), null);
+    const amt = try reader.readAll(data);
+    if (amt != object_size) {
+        return error.Io;
+    }
 
     var object = Object{
-        .file = try fs.cwd().openFile(self.name, .{}),
         .name = full_name,
+        .data = data,
     };
 
-    try object.parse(allocator, cpu_arch, try reader.context.getPos());
-    try reader.context.seekTo(0);
+    try object.parse(allocator, cpu_arch);
 
     return object;
 }

--- a/src/Elf/Archive.zig
+++ b/src/Elf/Archive.zig
@@ -198,10 +198,9 @@ pub fn parseObject(self: Archive, allocator: Allocator, cpu_arch: std.Target.Cpu
     var object = Object{
         .file = try fs.cwd().openFile(self.name, .{}),
         .name = full_name,
-        .file_offset = @intCast(u32, try reader.context.getPos()),
     };
 
-    try object.parse(allocator, cpu_arch);
+    try object.parse(allocator, cpu_arch, try reader.context.getPos());
     try reader.context.seekTo(0);
 
     return object;

--- a/src/Elf/Atom.zig
+++ b/src/Elf/Atom.zig
@@ -325,10 +325,11 @@ pub fn resolveRelocs(self: *Atom, elf_file: *Elf) !void {
                 const source = sym.st_value + rel.r_offset;
                 const target = self.getTargetAddress(r_sym, elf_file);
                 const base_addr: u64 = base_addr: {
-                    const shdr = if (elf_file.tbss_sect_index) |index|
-                        elf_file.shdrs.items[index]
+                    const index = if (elf_file.getSectionByName(".tbss")) |index|
+                        index
                     else
-                        elf_file.shdrs.items[elf_file.tdata_sect_index.?];
+                        elf_file.getSectionByName(".tdata").?;
+                    const shdr = elf_file.sections.items(.header)[index];
                     break :base_addr shdr.sh_addr + shdr.sh_size;
                 };
                 const tls_offset = @truncate(u32, @bitCast(u64, -@intCast(i64, base_addr - target) + rel.r_addend));

--- a/src/Elf/Atom.zig
+++ b/src/Elf/Atom.zig
@@ -329,7 +329,7 @@ pub fn resolveRelocs(self: *Atom, elf_file: *Elf) !void {
                         index
                     else
                         elf_file.getSectionByName(".tdata").?;
-                    const shdr = elf_file.sections.items(.header)[index];
+                    const shdr = elf_file.sections.items(.shdr)[index];
                     break :base_addr shdr.sh_addr + shdr.sh_size;
                 };
                 const tls_offset = @truncate(u32, @bitCast(u64, -@intCast(i64, base_addr - target) + rel.r_addend));

--- a/src/Elf/Object.zig
+++ b/src/Elf/Object.zig
@@ -455,6 +455,10 @@ pub fn getSymbolName(self: Object, index: u32) []const u8 {
     return self.getString(sym.st_name);
 }
 
+pub fn getAtomForSymbol(self: Object, sym_index: u32) ?*Atom {
+    return self.atom_table.get(sym_index);
+}
+
 pub fn getString(self: Object, off: u32) []const u8 {
     const strtab = self.getSourceStrtab();
     assert(off < strtab.len);

--- a/src/Elf/Object.zig
+++ b/src/Elf/Object.zig
@@ -103,7 +103,7 @@ pub fn scanInputSections(self: *Object, elf_file: *Elf) !void {
                 log.debug("unhandled section", .{});
                 continue;
             };
-            const out_shdr = elf_file.sections.items(.header)[tshdr_ndx];
+            const out_shdr = elf_file.sections.items(.shdr)[tshdr_ndx];
             log.debug("mapping '{s}' into output sect({d}, '{s}')", .{
                 shdr_name,
                 tshdr_ndx,

--- a/src/Elf/Object.zig
+++ b/src/Elf/Object.zig
@@ -19,26 +19,14 @@ const RegisterOrMemory = dis_x86_64.RegisterOrMemory;
 
 name: []const u8,
 data: []align(@alignOf(u64)) const u8,
-
 header: elf.Elf64_Ehdr = undefined,
-
-shdrs: std.ArrayListUnmanaged(elf.Elf64_Shdr) = .{},
-
-sections: std.ArrayListUnmanaged(u16) = .{},
-relocs: std.AutoHashMapUnmanaged(u16, u16) = .{},
+symtab_index: ?u16 = null,
 
 symtab: std.ArrayListUnmanaged(elf.Elf64_Sym) = .{},
-strtab: []const u8 = &.{},
-shstrtab: []const u8 = &.{},
 
 atom_table: std.AutoHashMapUnmanaged(u32, *Atom) = .{},
 
-symtab_index: ?u16 = null,
-
 pub fn deinit(self: *Object, allocator: Allocator) void {
-    self.shdrs.deinit(allocator);
-    self.sections.deinit(allocator);
-    self.relocs.deinit(allocator);
     self.symtab.deinit(allocator);
     self.atom_table.deinit(allocator);
     allocator.free(self.name);
@@ -87,64 +75,364 @@ pub fn parse(self: *Object, allocator: Allocator, cpu_arch: std.Target.Cpu.Arch)
     assert(self.header.e_phoff == 0);
     assert(self.header.e_phnum == 0);
 
-    const shnum = self.header.e_shnum;
-    if (shnum == 0) return;
+    if (self.header.e_shnum == 0) return;
 
-    try reader.context.seekTo(self.header.e_shoff);
-    try self.shdrs.ensureTotalCapacityPrecise(allocator, shnum);
-
-    var i: u16 = 0;
-    while (i < shnum) : (i += 1) {
-        const shdr = try reader.readStruct(elf.Elf64_Shdr);
-        self.shdrs.appendAssumeCapacity(shdr);
-
-        switch (shdr.sh_type) {
-            elf.SHT_SYMTAB => {
-                self.symtab_index = i;
-            },
-            elf.SHT_PROGBITS, elf.SHT_NOBITS => {
-                try self.sections.append(allocator, i);
-            },
-            elf.SHT_REL, elf.SHT_RELA => {
-                try self.relocs.putNoClobber(allocator, @intCast(u16, shdr.sh_info), i);
-            },
-            else => {},
-        }
-    }
-
-    // Parse shstrtab
-    self.shstrtab = self.readShdrContents(self.header.e_shstrndx);
-
-    try self.parseSymtab(allocator);
+    for (self.getShdrs()) |shdr, i| switch (shdr.sh_type) {
+        elf.SHT_SYMTAB => {
+            self.symtab_index = @intCast(u16, i);
+            const nsyms = @divExact(shdr.sh_size, @sizeOf(elf.Elf64_Sym));
+            try self.symtab.appendSlice(allocator, @ptrCast(
+                [*]const elf.Elf64_Sym,
+                @alignCast(@alignOf(elf.Elf64_Sym), &self.data[shdr.sh_offset]),
+            )[0..nsyms]);
+        },
+        else => {},
+    };
 }
 
-fn parseSymtab(self: *Object, allocator: Allocator) !void {
-    const symtab_index = self.symtab_index orelse return;
-    const symtab_shdr = self.shdrs.items[symtab_index];
-    self.strtab = self.readShdrContents(@intCast(u16, symtab_shdr.sh_link));
-    try self.symtab.appendSlice(allocator, self.getSourceSymtab());
+pub fn splitIntoAtoms(self: *Object, allocator: Allocator, object_id: u16, elf_file: *Elf) !void {
+    log.debug("parsing '{s}' into atoms", .{self.name});
+
+    var symbols_by_shndx = std.AutoHashMap(u16, std.ArrayList(u32)).init(allocator);
+    defer {
+        var it = symbols_by_shndx.valueIterator();
+        while (it.next()) |value| {
+            value.deinit();
+        }
+        symbols_by_shndx.deinit();
+    }
+
+    const shdrs = self.getShdrs();
+
+    var rel_shdrs = std.AutoHashMap(u16, u16).init(allocator);
+    defer rel_shdrs.deinit();
+
+    for (shdrs) |shdr, i| switch (shdr.sh_type) {
+        elf.SHT_REL, elf.SHT_RELA => {
+            try rel_shdrs.putNoClobber(@intCast(u16, shdr.sh_info), @intCast(u16, i));
+        },
+        else => {},
+    };
+
+    for (shdrs) |shdr, i| switch (shdr.sh_type) {
+        elf.SHT_PROGBITS, elf.SHT_NOBITS => {
+            try symbols_by_shndx.putNoClobber(@intCast(u16, i), std.ArrayList(u32).init(allocator));
+        },
+        else => {},
+    };
+
+    for (self.getSourceSymtab()) |sym, sym_id| {
+        if (sym.st_shndx == elf.SHN_UNDEF) continue;
+        if (elf.SHN_LORESERVE <= sym.st_shndx and sym.st_shndx < elf.SHN_HIRESERVE) continue;
+        const map = symbols_by_shndx.getPtr(sym.st_shndx) orelse continue;
+        try map.append(@intCast(u32, sym_id));
+    }
+
+    for (shdrs) |shdr, i| switch (shdr.sh_type) {
+        elf.SHT_PROGBITS, elf.SHT_NOBITS => {
+            const ndx = @intCast(u16, i);
+            const shdr_name = self.getShString(shdr.sh_name);
+
+            log.debug("  parsing section '{s}'", .{shdr_name});
+
+            if (shdr.sh_flags & elf.SHF_GROUP != 0) {
+                log.err("section '{s}' is part of a section group", .{shdr_name});
+                return error.HandleSectionGroups;
+            }
+
+            const tshdr_ndx = (try elf_file.getMatchingSection(object_id, ndx)) orelse {
+                log.debug("unhandled section", .{});
+                continue;
+            };
+
+            const syms = symbols_by_shndx.get(ndx).?;
+
+            const atom = try Atom.createEmpty(allocator);
+            errdefer {
+                atom.deinit(allocator);
+                allocator.destroy(atom);
+            }
+            try elf_file.managed_atoms.append(allocator, atom);
+
+            atom.file = object_id;
+            atom.size = @intCast(u32, shdr.sh_size);
+            atom.alignment = @intCast(u32, shdr.sh_addralign);
+
+            // TODO if --gc-sections and there is exactly one contained symbol,
+            // we can prune the main one. For example, in this situation we
+            // get something like this:
+            //
+            // .text.__udivti3
+            //    => __udivti3
+            //
+            // which can be pruned to:
+            //
+            // __udivti3
+            var local_sym_index: ?u32 = null;
+
+            for (syms.items) |sym_id| {
+                const sym = self.getSourceSymbol(sym_id);
+                const is_sect_sym = sym.st_info & 0xf == elf.STT_SECTION;
+                if (is_sect_sym) {
+                    const osym = self.getSymbolPtr(sym_id);
+                    osym.* = .{
+                        .st_name = 0,
+                        .st_info = (elf.STB_LOCAL << 4) | elf.STT_OBJECT,
+                        .st_other = 0,
+                        .st_shndx = 0,
+                        .st_value = 0,
+                        .st_size = sym.st_size,
+                    };
+                    local_sym_index = sym_id;
+                    continue;
+                }
+                try atom.contained.append(allocator, .{
+                    .local_sym_index = sym_id,
+                    .offset = sym.st_value,
+                });
+                try self.atom_table.putNoClobber(allocator, sym_id, atom);
+            }
+
+            atom.local_sym_index = local_sym_index orelse blk: {
+                const sym_index = @intCast(u32, self.symtab.items.len);
+                try self.symtab.append(allocator, .{
+                    .st_name = 0,
+                    .st_info = (elf.STB_LOCAL << 4) | elf.STT_OBJECT,
+                    .st_other = 0,
+                    .st_shndx = 0,
+                    .st_value = 0,
+                    .st_size = atom.size,
+                });
+                break :blk sym_index;
+            };
+            try self.atom_table.putNoClobber(allocator, atom.local_sym_index, atom);
+
+            var code = if (shdr.sh_type == elf.SHT_NOBITS) blk: {
+                var code = try allocator.alloc(u8, atom.size);
+                mem.set(u8, code, 0);
+                break :blk code;
+            } else try allocator.dupe(u8, self.getShdrContents(ndx));
+            defer allocator.free(code);
+
+            if (rel_shdrs.get(ndx)) |rel_ndx| {
+                const rel_shdr = shdrs[rel_ndx];
+                const raw_relocs = self.getShdrContents(rel_ndx);
+
+                const nrelocs = @divExact(rel_shdr.sh_size, rel_shdr.sh_entsize);
+                try atom.relocs.ensureTotalCapacityPrecise(allocator, nrelocs);
+
+                var count: usize = 0;
+                while (count < nrelocs) : (count += 1) {
+                    const bytes = raw_relocs[count * rel_shdr.sh_entsize ..][0..rel_shdr.sh_entsize];
+                    var rel = blk: {
+                        if (rel_shdr.sh_type == elf.SHT_REL) {
+                            const rel = @ptrCast(*const elf.Elf64_Rel, @alignCast(@alignOf(elf.Elf64_Rel), bytes)).*;
+                            // TODO parse addend from the placeholder
+                            // const addend = mem.readIntLittle(i32, code[rel.r_offset..][0..4]);
+                            // break :blk .{
+                            //     .r_offset = rel.r_offset,
+                            //     .r_info = rel.r_info,
+                            //     .r_addend = addend,
+                            // };
+                            log.err("TODO need to parse addend embedded in the relocation placeholder for SHT_REL", .{});
+                            log.err("  for relocation {}", .{rel});
+                            return error.TODOParseAddendFromPlaceholder;
+                        }
+
+                        break :blk @ptrCast(*const elf.Elf64_Rela, @alignCast(@alignOf(elf.Elf64_Rela), bytes)).*;
+                    };
+
+                    // While traversing relocations, synthesize any missing atom.
+                    // TODO synthesize PLT atoms, GOT atoms, etc.
+                    const tsym_name = self.getSourceSymbolName(rel.r_sym());
+                    switch (rel.r_type()) {
+                        elf.R_X86_64_REX_GOTPCRELX => blk: {
+                            const global = elf_file.globals.get(tsym_name).?;
+                            if (isDefinitionAvailable(elf_file, global)) opt: {
+                                // Link-time constant, try to optimize it away.
+                                var disassembler = Disassembler.init(code[rel.r_offset - 3 ..]);
+                                const maybe_inst = disassembler.next() catch break :opt;
+                                const inst = maybe_inst orelse break :opt;
+
+                                // TODO can we optimise anything that isn't an RM encoding?
+                                if (inst.enc != .rm) break :opt;
+                                const rm = inst.data.rm;
+                                if (rm.reg_or_mem != .mem) break :opt;
+                                if (rm.reg_or_mem.mem.base != .rip) break :opt;
+                                const dst = rm.reg;
+                                const src = rm.reg_or_mem;
+
+                                var stream = std.io.fixedBufferStream(code[rel.r_offset - 3 ..][0..7]);
+                                const writer = stream.writer();
+
+                                switch (inst.tag) {
+                                    .mov => {
+                                        // rewrite to LEA
+                                        const new_inst = Instruction{
+                                            .tag = .lea,
+                                            .enc = .rm,
+                                            .data = Instruction.Data.rm(dst, src),
+                                        };
+                                        try new_inst.encode(writer);
+
+                                        const r_sym = rel.r_sym();
+                                        rel.r_info = (@intCast(u64, r_sym) << 32) | elf.R_X86_64_PC32;
+                                        log.debug("rewriting R_X86_64_REX_GOTPCRELX -> R_X86_64_PC32: MOV -> LEA", .{});
+                                        break :blk;
+                                    },
+                                    .cmp => {
+                                        // rewrite to CMP MI encoding
+                                        const new_inst = Instruction{
+                                            .tag = .cmp,
+                                            .enc = .mi,
+                                            .data = Instruction.Data.mi(RegisterOrMemory.reg(dst), 0x0),
+                                        };
+                                        try new_inst.encode(writer);
+
+                                        const r_sym = rel.r_sym();
+                                        rel.r_info = (@intCast(u64, r_sym) << 32) | elf.R_X86_64_32;
+                                        rel.r_addend = 0;
+                                        log.debug("rewriting R_X86_64_REX_GOTPCRELX -> R_X86_64_32: CMP r64, r/m64 -> CMP r/m64, imm32", .{});
+
+                                        break :blk;
+                                    },
+                                    else => {},
+                                }
+                            }
+
+                            if (elf_file.got_entries_map.contains(global)) break :blk;
+                            log.debug("R_X86_64_REX_GOTPCRELX: creating GOT atom: [() -> {s}]", .{
+                                tsym_name,
+                            });
+                            const got_atom = try elf_file.createGotAtom(global);
+                            try elf_file.got_entries_map.putNoClobber(allocator, global, got_atom);
+                        },
+                        elf.R_X86_64_GOTPCREL => blk: {
+                            const global = elf_file.globals.get(tsym_name).?;
+                            if (elf_file.got_entries_map.contains(global)) break :blk;
+                            log.debug("R_X86_64_GOTPCREL: creating GOT atom: [() -> {s}]", .{
+                                tsym_name,
+                            });
+                            const got_atom = try elf_file.createGotAtom(global);
+                            try elf_file.got_entries_map.putNoClobber(allocator, global, got_atom);
+                        },
+                        elf.R_X86_64_GOTTPOFF => blk: {
+                            const global = elf_file.globals.get(tsym_name).?;
+                            if (isDefinitionAvailable(elf_file, global)) {
+                                // Link-time constant, try to optimize it away.
+                                var disassembler = Disassembler.init(code[rel.r_offset - 3 ..]);
+                                const maybe_inst = disassembler.next() catch break :blk;
+                                const inst = maybe_inst orelse break :blk;
+
+                                if (inst.enc != .rm) break :blk;
+                                const rm = inst.data.rm;
+                                if (rm.reg_or_mem != .mem) break :blk;
+                                if (rm.reg_or_mem.mem.base != .rip) break :blk;
+                                const dst = rm.reg;
+
+                                var stream = std.io.fixedBufferStream(code[rel.r_offset - 3 ..][0..7]);
+                                const writer = stream.writer();
+
+                                switch (inst.tag) {
+                                    .mov => {
+                                        // rewrite to MOV MI encoding
+                                        const new_inst = Instruction{
+                                            .tag = .mov,
+                                            .enc = .mi,
+                                            .data = Instruction.Data.mi(RegisterOrMemory.reg(dst), 0x0),
+                                        };
+                                        try new_inst.encode(writer);
+
+                                        const r_sym = rel.r_sym();
+                                        rel.r_info = (@intCast(u64, r_sym) << 32) | elf.R_X86_64_TPOFF32;
+                                        rel.r_addend = 0;
+                                        log.debug("rewriting R_X86_64_GOTTPOFF -> R_X86_64_TPOFF32: MOV r64, r/m64 -> MOV r/m64, imm32", .{});
+                                    },
+                                    else => {},
+                                }
+                            }
+                        },
+                        elf.R_X86_64_DTPOFF64 => {
+                            const global = elf_file.globals.get(tsym_name).?;
+                            if (isDefinitionAvailable(elf_file, global)) {
+                                // rewrite into TPOFF32
+                                const r_sym = rel.r_sym();
+                                rel.r_info = (@intCast(u64, r_sym) << 32) | elf.R_X86_64_TPOFF32;
+                                rel.r_addend = 0;
+                                log.debug("rewriting R_X86_64_DTPOFF64 -> R_X86_64_TPOFF32", .{});
+                            }
+                        },
+                        else => {},
+                    }
+
+                    atom.relocs.appendAssumeCapacity(rel);
+                }
+            }
+
+            try atom.code.appendSlice(allocator, code);
+
+            // Update target section's metadata
+            const tshdr = &elf_file.shdrs.items[tshdr_ndx];
+            tshdr.sh_addralign = math.max(tshdr.sh_addralign, atom.alignment);
+            tshdr.sh_size = mem.alignForwardGeneric(
+                u64,
+                mem.alignForwardGeneric(u64, tshdr.sh_size, atom.alignment) + atom.size,
+                tshdr.sh_addralign,
+            );
+
+            if (elf_file.atoms.getPtr(tshdr_ndx)) |last| {
+                last.*.?.next = atom;
+                atom.prev = last.*.?;
+                last.* = atom;
+            } else {
+                try elf_file.atoms.putNoClobber(allocator, tshdr_ndx, atom);
+            }
+        },
+        else => {},
+    };
+}
+
+pub inline fn getShdrs(self: Object) []const elf.Elf64_Shdr {
+    return @ptrCast(
+        [*]const elf.Elf64_Shdr,
+        @alignCast(@alignOf(elf.Elf64_Shdr), &self.data[self.header.e_shoff]),
+    )[0..self.header.e_shnum];
+}
+
+inline fn getShdrContents(self: Object, index: u16) []const u8 {
+    const shdr = self.getShdrs()[index];
+    return self.data[shdr.sh_offset..][0..shdr.sh_size];
 }
 
 pub fn getSourceSymtab(self: Object) []const elf.Elf64_Sym {
     const index = self.symtab_index orelse return &[0]elf.Elf64_Sym{};
-    const raw_symtab = self.readShdrContents(index);
-    return mem.bytesAsSlice(elf.Elf64_Sym, @alignCast(@alignOf(elf.Elf64_Sym), raw_symtab));
+    const shdr = self.getShdrs()[index];
+    const nsyms = @divExact(shdr.sh_size, @sizeOf(elf.Elf64_Sym));
+    return @ptrCast(
+        [*]const elf.Elf64_Sym,
+        @alignCast(@alignOf(elf.Elf64_Sym), &self.data[shdr.sh_offset]),
+    )[0..nsyms];
 }
 
-pub fn getSourceSymbol(self: Object, index: u32) ?elf.Elf64_Sym {
+pub fn getSourceStrtab(self: Object) []const u8 {
+    const index = self.symtab_index orelse return &[0]u8{};
+    const shdr = self.getShdrs()[index];
+    return self.getShdrContents(@intCast(u16, shdr.sh_link));
+}
+
+pub fn getSourceShstrtab(self: Object) []const u8 {
+    return self.getShdrContents(self.header.e_shstrndx);
+}
+
+pub fn getSourceSymbol(self: Object, index: u32) elf.Elf64_Sym {
     const symtab = self.getSourceSymtab();
     return symtab[index];
 }
 
-pub fn getSourceShdr(self: Object, index: u16) elf.Elf64_Shdr {
-    assert(index < self.shdrs.items.len);
-    return self.shdrs.items[index];
-}
-
 pub fn getSourceSymbolName(self: Object, index: u32) []const u8 {
-    const sym = self.getSourceSymbol(index).?;
+    const sym = self.getSourceSymtab()[index];
     if (sym.st_info & 0xf == elf.STT_SECTION) {
-        const shdr = self.shdrs.items[sym.st_shndx];
+        const shdr = self.getShdrs()[sym.st_shndx];
         return self.getShString(shdr.sh_name);
     } else {
         return self.getString(sym.st_name);
@@ -164,287 +452,16 @@ pub fn getSymbolName(self: Object, index: u32) []const u8 {
     return self.getString(sym.st_name);
 }
 
-pub fn parseIntoAtoms(self: *Object, allocator: Allocator, object_id: u16, elf_file: *Elf) !void {
-    log.debug("parsing '{s}' into atoms", .{self.name});
+pub fn getString(self: Object, off: u32) []const u8 {
+    const strtab = self.getSourceStrtab();
+    assert(off < strtab.len);
+    return mem.sliceTo(@ptrCast([*:0]const u8, strtab.ptr + off), 0);
+}
 
-    var symbols_by_shndx = std.AutoHashMap(u16, std.ArrayList(u32)).init(allocator);
-    defer {
-        var it = symbols_by_shndx.valueIterator();
-        while (it.next()) |value| {
-            value.deinit();
-        }
-        symbols_by_shndx.deinit();
-    }
-
-    for (self.sections.items) |ndx| {
-        try symbols_by_shndx.putNoClobber(ndx, std.ArrayList(u32).init(allocator));
-    }
-    for (self.getSourceSymtab()) |sym, sym_id| {
-        if (sym.st_shndx == elf.SHN_UNDEF) continue;
-        if (elf.SHN_LORESERVE <= sym.st_shndx and sym.st_shndx < elf.SHN_HIRESERVE) continue;
-        const map = symbols_by_shndx.getPtr(sym.st_shndx) orelse continue;
-        try map.append(@intCast(u32, sym_id));
-    }
-
-    for (self.sections.items) |ndx| {
-        const shdr = self.getSourceShdr(ndx);
-        const shdr_name = self.getShString(shdr.sh_name);
-
-        log.debug("  parsing section '{s}'", .{shdr_name});
-
-        if (shdr.sh_flags & elf.SHF_GROUP != 0) {
-            log.err("section '{s}' is part of a section group", .{shdr_name});
-            return error.HandleSectionGroups;
-        }
-
-        const tshdr_ndx = (try elf_file.getMatchingSection(object_id, ndx)) orelse {
-            log.debug("unhandled section", .{});
-            continue;
-        };
-
-        const syms = symbols_by_shndx.get(ndx).?;
-
-        const atom = try Atom.createEmpty(allocator);
-        errdefer {
-            atom.deinit(allocator);
-            allocator.destroy(atom);
-        }
-        try elf_file.managed_atoms.append(allocator, atom);
-
-        atom.file = object_id;
-        atom.size = @intCast(u32, shdr.sh_size);
-        atom.alignment = @intCast(u32, shdr.sh_addralign);
-
-        // TODO if --gc-sections and there is exactly one contained symbol,
-        // we can prune the main one. For example, in this situation we
-        // get something like this:
-        //
-        // .text.__udivti3
-        //    => __udivti3
-        //
-        // which can be pruned to:
-        //
-        // __udivti3
-        var local_sym_index: ?u32 = null;
-
-        for (syms.items) |sym_id| {
-            const sym = self.getSourceSymbol(sym_id).?;
-            const is_sect_sym = sym.st_info & 0xf == elf.STT_SECTION;
-            if (is_sect_sym) {
-                const osym = self.getSymbolPtr(sym_id);
-                osym.* = .{
-                    .st_name = 0,
-                    .st_info = (elf.STB_LOCAL << 4) | elf.STT_OBJECT,
-                    .st_other = 0,
-                    .st_shndx = 0,
-                    .st_value = 0,
-                    .st_size = sym.st_size,
-                };
-                local_sym_index = sym_id;
-                continue;
-            }
-            try atom.contained.append(allocator, .{
-                .local_sym_index = sym_id,
-                .offset = sym.st_value,
-            });
-            try self.atom_table.putNoClobber(allocator, sym_id, atom);
-        }
-
-        atom.local_sym_index = local_sym_index orelse blk: {
-            const sym_index = @intCast(u32, self.symtab.items.len);
-            try self.symtab.append(allocator, .{
-                .st_name = 0,
-                .st_info = (elf.STB_LOCAL << 4) | elf.STT_OBJECT,
-                .st_other = 0,
-                .st_shndx = 0,
-                .st_value = 0,
-                .st_size = atom.size,
-            });
-            break :blk sym_index;
-        };
-        try self.atom_table.putNoClobber(allocator, atom.local_sym_index, atom);
-
-        var code = if (shdr.sh_type == elf.SHT_NOBITS) blk: {
-            var code = try allocator.alloc(u8, atom.size);
-            mem.set(u8, code, 0);
-            break :blk code;
-        } else try allocator.dupe(u8, self.readShdrContents(ndx));
-        defer allocator.free(code);
-
-        if (self.relocs.get(ndx)) |rel_ndx| {
-            const rel_shdr = self.getSourceShdr(rel_ndx);
-            const raw_relocs = self.readShdrContents(rel_ndx);
-
-            const nrelocs = @divExact(rel_shdr.sh_size, rel_shdr.sh_entsize);
-            try atom.relocs.ensureTotalCapacityPrecise(allocator, nrelocs);
-
-            var count: usize = 0;
-            while (count < nrelocs) : (count += 1) {
-                const bytes = raw_relocs[count * rel_shdr.sh_entsize ..][0..rel_shdr.sh_entsize];
-                var rel = blk: {
-                    if (rel_shdr.sh_type == elf.SHT_REL) {
-                        const rel = @ptrCast(*const elf.Elf64_Rel, @alignCast(@alignOf(elf.Elf64_Rel), bytes)).*;
-                        // TODO parse addend from the placeholder
-                        // const addend = mem.readIntLittle(i32, code[rel.r_offset..][0..4]);
-                        // break :blk .{
-                        //     .r_offset = rel.r_offset,
-                        //     .r_info = rel.r_info,
-                        //     .r_addend = addend,
-                        // };
-                        log.err("TODO need to parse addend embedded in the relocation placeholder for SHT_REL", .{});
-                        log.err("  for relocation {}", .{rel});
-                        return error.TODOParseAddendFromPlaceholder;
-                    }
-
-                    break :blk @ptrCast(*const elf.Elf64_Rela, @alignCast(@alignOf(elf.Elf64_Rela), bytes)).*;
-                };
-
-                // While traversing relocations, synthesize any missing atom.
-                // TODO synthesize PLT atoms, GOT atoms, etc.
-                const tsym_name = self.getSourceSymbolName(rel.r_sym());
-                switch (rel.r_type()) {
-                    elf.R_X86_64_REX_GOTPCRELX => blk: {
-                        const global = elf_file.globals.get(tsym_name).?;
-                        if (isDefinitionAvailable(elf_file, global)) opt: {
-                            // Link-time constant, try to optimize it away.
-                            var disassembler = Disassembler.init(code[rel.r_offset - 3 ..]);
-                            const maybe_inst = disassembler.next() catch break :opt;
-                            const inst = maybe_inst orelse break :opt;
-
-                            // TODO can we optimise anything that isn't an RM encoding?
-                            if (inst.enc != .rm) break :opt;
-                            const rm = inst.data.rm;
-                            if (rm.reg_or_mem != .mem) break :opt;
-                            if (rm.reg_or_mem.mem.base != .rip) break :opt;
-                            const dst = rm.reg;
-                            const src = rm.reg_or_mem;
-
-                            var stream = std.io.fixedBufferStream(code[rel.r_offset - 3 ..][0..7]);
-                            const writer = stream.writer();
-
-                            switch (inst.tag) {
-                                .mov => {
-                                    // rewrite to LEA
-                                    const new_inst = Instruction{
-                                        .tag = .lea,
-                                        .enc = .rm,
-                                        .data = Instruction.Data.rm(dst, src),
-                                    };
-                                    try new_inst.encode(writer);
-
-                                    const r_sym = rel.r_sym();
-                                    rel.r_info = (@intCast(u64, r_sym) << 32) | elf.R_X86_64_PC32;
-                                    log.debug("rewriting R_X86_64_REX_GOTPCRELX -> R_X86_64_PC32: MOV -> LEA", .{});
-                                    break :blk;
-                                },
-                                .cmp => {
-                                    // rewrite to CMP MI encoding
-                                    const new_inst = Instruction{
-                                        .tag = .cmp,
-                                        .enc = .mi,
-                                        .data = Instruction.Data.mi(RegisterOrMemory.reg(dst), 0x0),
-                                    };
-                                    try new_inst.encode(writer);
-
-                                    const r_sym = rel.r_sym();
-                                    rel.r_info = (@intCast(u64, r_sym) << 32) | elf.R_X86_64_32;
-                                    rel.r_addend = 0;
-                                    log.debug("rewriting R_X86_64_REX_GOTPCRELX -> R_X86_64_32: CMP r64, r/m64 -> CMP r/m64, imm32", .{});
-
-                                    break :blk;
-                                },
-                                else => {},
-                            }
-                        }
-
-                        if (elf_file.got_entries_map.contains(global)) break :blk;
-                        log.debug("R_X86_64_REX_GOTPCRELX: creating GOT atom: [() -> {s}]", .{
-                            tsym_name,
-                        });
-                        const got_atom = try elf_file.createGotAtom(global);
-                        try elf_file.got_entries_map.putNoClobber(allocator, global, got_atom);
-                    },
-                    elf.R_X86_64_GOTPCREL => blk: {
-                        const global = elf_file.globals.get(tsym_name).?;
-                        if (elf_file.got_entries_map.contains(global)) break :blk;
-                        log.debug("R_X86_64_GOTPCREL: creating GOT atom: [() -> {s}]", .{
-                            tsym_name,
-                        });
-                        const got_atom = try elf_file.createGotAtom(global);
-                        try elf_file.got_entries_map.putNoClobber(allocator, global, got_atom);
-                    },
-                    elf.R_X86_64_GOTTPOFF => blk: {
-                        const global = elf_file.globals.get(tsym_name).?;
-                        if (isDefinitionAvailable(elf_file, global)) {
-                            // Link-time constant, try to optimize it away.
-                            var disassembler = Disassembler.init(code[rel.r_offset - 3 ..]);
-                            const maybe_inst = disassembler.next() catch break :blk;
-                            const inst = maybe_inst orelse break :blk;
-
-                            if (inst.enc != .rm) break :blk;
-                            const rm = inst.data.rm;
-                            if (rm.reg_or_mem != .mem) break :blk;
-                            if (rm.reg_or_mem.mem.base != .rip) break :blk;
-                            const dst = rm.reg;
-
-                            var stream = std.io.fixedBufferStream(code[rel.r_offset - 3 ..][0..7]);
-                            const writer = stream.writer();
-
-                            switch (inst.tag) {
-                                .mov => {
-                                    // rewrite to MOV MI encoding
-                                    const new_inst = Instruction{
-                                        .tag = .mov,
-                                        .enc = .mi,
-                                        .data = Instruction.Data.mi(RegisterOrMemory.reg(dst), 0x0),
-                                    };
-                                    try new_inst.encode(writer);
-
-                                    const r_sym = rel.r_sym();
-                                    rel.r_info = (@intCast(u64, r_sym) << 32) | elf.R_X86_64_TPOFF32;
-                                    rel.r_addend = 0;
-                                    log.debug("rewriting R_X86_64_GOTTPOFF -> R_X86_64_TPOFF32: MOV r64, r/m64 -> MOV r/m64, imm32", .{});
-                                },
-                                else => {},
-                            }
-                        }
-                    },
-                    elf.R_X86_64_DTPOFF64 => {
-                        const global = elf_file.globals.get(tsym_name).?;
-                        if (isDefinitionAvailable(elf_file, global)) {
-                            // rewrite into TPOFF32
-                            const r_sym = rel.r_sym();
-                            rel.r_info = (@intCast(u64, r_sym) << 32) | elf.R_X86_64_TPOFF32;
-                            rel.r_addend = 0;
-                            log.debug("rewriting R_X86_64_DTPOFF64 -> R_X86_64_TPOFF32", .{});
-                        }
-                    },
-                    else => {},
-                }
-
-                atom.relocs.appendAssumeCapacity(rel);
-            }
-        }
-
-        try atom.code.appendSlice(allocator, code);
-
-        // Update target section's metadata
-        const tshdr = &elf_file.shdrs.items[tshdr_ndx];
-        tshdr.sh_addralign = math.max(tshdr.sh_addralign, atom.alignment);
-        tshdr.sh_size = mem.alignForwardGeneric(
-            u64,
-            mem.alignForwardGeneric(u64, tshdr.sh_size, atom.alignment) + atom.size,
-            tshdr.sh_addralign,
-        );
-
-        if (elf_file.atoms.getPtr(tshdr_ndx)) |last| {
-            last.*.?.next = atom;
-            atom.prev = last.*.?;
-            last.* = atom;
-        } else {
-            try elf_file.atoms.putNoClobber(allocator, tshdr_ndx, atom);
-        }
-    }
+pub fn getShString(self: Object, off: u32) []const u8 {
+    const shstrtab = self.getSourceShstrtab();
+    assert(off < shstrtab.len);
+    return mem.sliceTo(@ptrCast([*:0]const u8, shstrtab.ptr + off), 0);
 }
 
 fn isDefinitionAvailable(elf_file: *Elf, global: Elf.SymbolWithLoc) bool {
@@ -453,19 +470,4 @@ fn isDefinitionAvailable(elf_file: *Elf, global: Elf.SymbolWithLoc) bool {
         break :sym object.symtab.items[global.sym_index];
     } else elf_file.locals.items[global.sym_index];
     return sym.st_info & 0xf != elf.STT_NOTYPE or sym.st_shndx != elf.SHN_UNDEF;
-}
-
-pub fn getString(self: Object, off: u32) []const u8 {
-    assert(off < self.strtab.len);
-    return mem.sliceTo(@ptrCast([*:0]const u8, self.strtab.ptr + off), 0);
-}
-
-pub fn getShString(self: Object, off: u32) []const u8 {
-    assert(off < self.shstrtab.len);
-    return mem.sliceTo(@ptrCast([*:0]const u8, self.shstrtab.ptr + off), 0);
-}
-
-fn readShdrContents(self: Object, shdr_index: u16) []const u8 {
-    const shdr = self.shdrs.items[shdr_index];
-    return self.data[shdr.sh_offset..][0..shdr.sh_size];
 }

--- a/src/Elf/Object.zig
+++ b/src/Elf/Object.zig
@@ -140,7 +140,7 @@ pub fn splitIntoAtoms(self: *Object, allocator: Allocator, object_id: u16, elf_f
                 return error.HandleSectionGroups;
             }
 
-            const tshdr_ndx = (try elf_file.getMatchingSection(object_id, ndx)) orelse {
+            const tshdr_ndx = (try elf_file.getOutputSection(shdr, shdr_name)) orelse {
                 log.debug("unhandled section", .{});
                 continue;
             };

--- a/src/Elf/Options.zig
+++ b/src/Elf/Options.zig
@@ -15,7 +15,7 @@ const usage =
     \\Usage: {s} [files...]
     \\
     \\General Options:
-    \\--entry=[name]                Set name of the entry point symbol
+    \\--entry=[name], -e [name]     Set name of the entry point symbol
     \\--gc-sections                 Force removal of functions and data that are unreachable by the entry point or exported symbols
     \\-l[name]                      Specify library to link against
     \\-L[path]                      Specify library search dir
@@ -111,6 +111,8 @@ pub fn parseArgs(arena: Allocator, ctx: Zld.MainCtx) !Options {
             try rpath_list.append(rpath);
         } else if (mem.startsWith(u8, arg, "--entry=")) {
             entry = arg["--entry=".len..];
+        } else if (mem.eql(u8, arg, "-e")) {
+            entry = args_iter.next() orelse ctx.printFailure("Expected name after {s}", .{arg});
         } else {
             try positionals.append(.{
                 .path = arg,

--- a/src/Elf/gc.zig
+++ b/src/Elf/gc.zig
@@ -1,0 +1,202 @@
+const std = @import("std");
+const assert = std.debug.assert;
+const elf = std.elf;
+const log = std.log.scoped(.gc);
+const mem = std.mem;
+
+const Allocator = mem.Allocator;
+const Atom = @import("Atom.zig");
+const Elf = @import("../Elf.zig");
+
+pub fn gcAtoms(elf_file: *Elf) !void {
+    const gpa = elf_file.base.allocator;
+    var arena_allocator = std.heap.ArenaAllocator.init(gpa);
+    defer arena_allocator.deinit();
+    const arena = arena_allocator.allocator();
+
+    var roots = std.AutoHashMap(*Atom, void).init(arena);
+    try collectRoots(&roots, elf_file);
+
+    var alive = std.AutoHashMap(*Atom, void).init(arena);
+    try mark(roots, &alive, elf_file);
+
+    try prune(arena, alive, elf_file);
+}
+
+fn removeAtomFromSection(atom: *Atom, match: u16, elf_file: *Elf) void {
+    var section = elf_file.sections.get(match);
+
+    // If we want to enable GC for incremental codepath, we need to take into
+    // account any padding that might have been left here.
+    section.shdr.sh_size -= atom.size;
+
+    if (atom.prev) |prev| {
+        prev.next = atom.next;
+    }
+    if (atom.next) |next| {
+        next.prev = atom.prev;
+    } else {
+        if (atom.prev) |prev| {
+            section.last_atom = prev;
+        } else {
+            // The section will be GCed in the next step.
+            section.last_atom = null;
+            section.shdr.sh_size = 0;
+        }
+    }
+
+    elf_file.sections.set(match, section);
+}
+
+fn collectRoots(roots: *std.AutoHashMap(*Atom, void), elf_file: *Elf) !void {
+    const output_mode = elf_file.options.output_mode;
+
+    switch (output_mode) {
+        .exe => {
+            for (&[_][]const u8{ "_init", "_fini" }) |sym_name| {
+                const global = elf_file.globals.get(sym_name) orelse continue;
+                const atom = elf_file.getAtomForSymbol(global).?;
+                _ = try roots.getOrPut(atom);
+            }
+            const global = try elf_file.getEntryPoint();
+            const atom = elf_file.getAtomForSymbol(global).?;
+            _ = try roots.getOrPut(atom);
+        },
+        else => |other| {
+            assert(other == .lib);
+            for (elf_file.globals.values()) |global| {
+                const sym = elf_file.getSymbol(global);
+                if (sym.st_shndx == elf.SHN_UNDEF) continue;
+                const atom = elf_file.getAtomForSymbol(global).?;
+                _ = try roots.getOrPut(atom);
+            }
+        },
+    }
+
+    for (elf_file.objects.items) |object| {
+        const shdrs = object.getShdrs();
+
+        for (object.managed_atoms.items) |atom| {
+            const sym = object.getSourceSymbol(atom.sym_index) orelse continue;
+            const shdr = shdrs[sym.st_shndx];
+            const sh_name = object.getShString(shdr.sh_name);
+            const is_gc_root = blk: {
+                if (shdr.sh_type == elf.SHT_PREINIT_ARRAY) break :blk true;
+                if (shdr.sh_type == elf.SHT_INIT_ARRAY) break :blk true;
+                if (shdr.sh_type == elf.SHT_FINI_ARRAY) break :blk true;
+                if (mem.startsWith(u8, ".ctors", sh_name)) break :blk true;
+                if (mem.startsWith(u8, ".dtors", sh_name)) break :blk true;
+                if (mem.startsWith(u8, ".init", sh_name)) break :blk true;
+                if (mem.startsWith(u8, ".fini", sh_name)) break :blk true;
+                if (mem.startsWith(u8, ".jcr", sh_name)) break :blk true;
+                if (mem.indexOf(u8, sh_name, "KEEP") != null) break :blk true;
+                break :blk false;
+            };
+            if (is_gc_root) {
+                _ = try roots.getOrPut(atom);
+            }
+        }
+    }
+}
+
+fn markLive(atom: *Atom, alive: *std.AutoHashMap(*Atom, void), elf_file: *Elf) anyerror!void {
+    const gop = try alive.getOrPut(atom);
+    if (gop.found_existing) return;
+
+    log.debug("marking live", .{});
+    elf_file.logAtom(atom, log);
+
+    for (atom.relocs.items) |rel| {
+        const target_atom = atom.getTargetAtom(elf_file, rel) orelse continue;
+        try markLive(target_atom, alive, elf_file);
+    }
+}
+
+fn mark(roots: std.AutoHashMap(*Atom, void), alive: *std.AutoHashMap(*Atom, void), elf_file: *Elf) !void {
+    try alive.ensureUnusedCapacity(roots.count());
+
+    var it = roots.keyIterator();
+    while (it.next()) |root| {
+        try markLive(root.*, alive, elf_file);
+    }
+}
+
+fn prune(arena: Allocator, alive: std.AutoHashMap(*Atom, void), elf_file: *Elf) !void {
+    // Any section that ends up here will be updated, that is,
+    // its size and alignment recalculated.
+    var gc_sections = std.AutoHashMap(u16, void).init(arena);
+
+    for (elf_file.objects.items) |object| {
+        for (object.managed_atoms.items) |atom| {
+            if (alive.contains(atom)) continue;
+
+            const global = atom.getSymbolWithLoc();
+            const sym = atom.getSymbolPtr(elf_file);
+            const tshdr = elf_file.sections.items(.shdr)[sym.st_shndx];
+            const tshdr_name = elf_file.shstrtab.getAssumeExists(tshdr.sh_name);
+
+            if (sym.st_other == Elf.STV_GC) continue;
+            if (mem.startsWith(u8, tshdr_name, ".debug")) continue;
+            if (mem.startsWith(u8, tshdr_name, ".comment")) continue;
+
+            log.debug("pruning:", .{});
+            elf_file.logAtom(atom, log);
+            sym.st_other = Elf.STV_GC;
+            removeAtomFromSection(atom, sym.st_shndx, elf_file);
+            _ = try gc_sections.put(sym.st_shndx, {});
+
+            for (atom.contained.items) |sym_off| {
+                const inner = elf_file.getSymbolPtr(.{
+                    .sym_index = sym_off.sym_index,
+                    .file = atom.file,
+                });
+                inner.st_other = Elf.STV_GC;
+            }
+
+            if (elf_file.got_entries_map.contains(global)) {
+                const got_atom = elf_file.got_entries_map.get(global).?;
+                const got_sym = got_atom.getSymbolPtr(elf_file);
+                got_sym.st_other = Elf.STV_GC;
+            }
+        }
+
+        for (elf_file.got_entries_map.keys()) |sym_loc| {
+            const sym = elf_file.getSymbol(sym_loc);
+            if (sym.st_other != Elf.STV_GC) continue;
+
+            // TODO tombstone
+            const atom = elf_file.got_entries_map.get(sym_loc).?;
+            removeAtomFromSection(atom, sym.st_shndx, elf_file);
+            _ = try gc_sections.put(sym.st_shndx, {});
+        }
+
+        var gc_sections_it = gc_sections.iterator();
+        while (gc_sections_it.next()) |entry| {
+            const match = entry.key_ptr.*;
+            var section = elf_file.sections.get(match);
+            if (section.shdr.sh_size == 0) continue; // Pruning happens automatically in next step.
+
+            section.shdr.sh_addralign = 0;
+            section.shdr.sh_size = 0;
+
+            var atom = section.last_atom.?;
+
+            while (atom.prev) |prev| {
+                atom = prev;
+            }
+
+            while (true) {
+                const aligned_end_addr = mem.alignForwardGeneric(u64, section.shdr.sh_size, atom.alignment);
+                const padding = aligned_end_addr - section.shdr.sh_size;
+                section.shdr.sh_size += padding + atom.size;
+                section.shdr.sh_addralign = @maximum(section.shdr.sh_addralign, atom.alignment);
+
+                if (atom.next) |next| {
+                    atom = next;
+                } else break;
+            }
+
+            elf_file.sections.set(match, section);
+        }
+    }
+}

--- a/src/MachO/dead_strip.zig
+++ b/src/MachO/dead_strip.zig
@@ -139,11 +139,7 @@ fn refersDead(atom: *Atom, macho_file: *MachO) bool {
     return false;
 }
 
-fn mark(
-    roots: std.AutoHashMap(*Atom, void),
-    alive: *std.AutoHashMap(*Atom, void),
-    macho_file: *MachO,
-) !void {
+fn mark(roots: std.AutoHashMap(*Atom, void), alive: *std.AutoHashMap(*Atom, void), macho_file: *MachO) !void {
     try alive.ensureUnusedCapacity(roots.count());
 
     var it = roots.keyIterator();

--- a/src/test.zig
+++ b/src/test.zig
@@ -295,6 +295,7 @@ pub const TestContext = struct {
                     .lib_dirs = lib_dirs.items,
                     .framework_dirs = framework_dirs.items,
                     .rpath_list = &[0][]const u8{},
+                    .dead_strip = true,
                 } },
                 .elf => .{ .elf = .{
                     .emit = .{
@@ -307,6 +308,7 @@ pub const TestContext = struct {
                     .libs = libs,
                     .lib_dirs = lib_dirs.items,
                     .rpath_list = &[0][]const u8{},
+                    .gc_sections = true,
                 } },
                 .coff => .{ .coff = .{
                     .emit = .{

--- a/src/test.zig
+++ b/src/test.zig
@@ -295,7 +295,6 @@ pub const TestContext = struct {
                     .lib_dirs = lib_dirs.items,
                     .framework_dirs = framework_dirs.items,
                     .rpath_list = &[0][]const u8{},
-                    .dead_strip = true,
                 } },
                 .elf => .{ .elf = .{
                     .emit = .{
@@ -308,7 +307,6 @@ pub const TestContext = struct {
                     .libs = libs,
                     .lib_dirs = lib_dirs.items,
                     .rpath_list = &[0][]const u8{},
-                    .gc_sections = true,
                 } },
                 .coff => .{ .coff = .{
                     .emit = .{


### PR DESCRIPTION
In summary, reduce number of redundant LOCs making the codebase more manageable, reduce memory allocs for parsed objects/archives, improve GC mechanism and move to separate module `Elf/gc.zig`, simplify inserting new sections from input files (uses section precedence and always keeps sections pre-sorted).

TODO when GCing atoms, if a section header should cease to exist, it is currently not removed from the output file.