### PR TITLE
Add Tracy integration and fix performance regression in MachO x86_64

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -15,6 +15,7 @@ pub fn build(b: *Builder) void {
 
     const enable_logging = b.option(bool, "log", "Whether to enable logging") orelse false;
     const is_qemu_enabled = b.option(bool, "enable-qemu", "Use QEMU to run cross compiled foreign architecture tests") orelse false;
+    const enable_tracy = b.option([]const u8, "tracy", "Enable Tracy integration. Supply path to Tracy source");
 
     const lib = b.addStaticLibrary("zld", "src/Zld.zig");
     lib.setTarget(target);
@@ -30,6 +31,33 @@ pub fn build(b: *Builder) void {
     const exe_opts = b.addOptions();
     exe.addOptions("build_options", exe_opts);
     exe_opts.addOption(bool, "enable_logging", enable_logging);
+    exe_opts.addOption(bool, "enable_tracy", enable_tracy != null);
+
+    if (enable_tracy) |tracy_path| {
+        const client_cpp = fs.path.join(
+            b.allocator,
+            &[_][]const u8{ tracy_path, "TracyClient.cpp" },
+        ) catch unreachable;
+
+        // On mingw, we need to opt into windows 7+ to get some features required by tracy.
+        const tracy_c_flags: []const []const u8 = if (target.isWindows() and target.getAbi() == .gnu)
+            &[_][]const u8{ "-DTRACY_ENABLE=1", "-fno-sanitize=undefined", "-D_WIN32_WINNT=0x601" }
+        else
+            &[_][]const u8{ "-DTRACY_ENABLE=1", "-fno-sanitize=undefined" };
+
+        exe.addIncludePath(tracy_path);
+        // TODO: upstream bug
+        exe.addSystemIncludePath("/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include");
+        exe.addCSourceFile(client_cpp, tracy_c_flags);
+        exe.linkSystemLibraryName("c++");
+        exe.linkLibC();
+        exe.strip = false;
+
+        if (target.isWindows()) {
+            exe.linkSystemLibrary("dbghelp");
+            exe.linkSystemLibrary("ws2_32");
+        }
+    }
     exe.install();
 
     const gen_symlinks = symlinks(exe, &[_][]const u8{

--- a/build.zig
+++ b/build.zig
@@ -47,7 +47,7 @@ pub fn build(b: *Builder) void {
 
         exe.addIncludePath(tracy_path);
         // TODO: upstream bug
-        exe.addSystemIncludePath("/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include");
+        exe.addSystemIncludePath("/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include");
         exe.addCSourceFile(client_cpp, tracy_c_flags);
         exe.linkSystemLibraryName("c++");
         exe.linkLibC();

--- a/src/MachO.zig
+++ b/src/MachO.zig
@@ -4111,6 +4111,7 @@ fn logSymtab(self: *MachO) void {
             });
         }
     }
+
     scoped_log.debug("  object(-1)", .{});
     for (self.locals.items) |sym, sym_id| {
         if (sym.undf()) continue;

--- a/src/MachO/Atom.zig
+++ b/src/MachO/Atom.zig
@@ -634,7 +634,7 @@ fn resolveRelocsArm64(
                         ), code),
                     };
                     const off = try calcPageOffset(adjusted_target_addr, switch (inst.load_store_register.size) {
-                        0 => if (inst.load_store_register.v == 1) .load_store_128 else .load_store_8,
+                        0 => if (inst.load_store_register.v == 1) PageOffsetInstKind.load_store_128 else PageOffsetInstKind.load_store_8,
                         1 => .load_store_16,
                         2 => .load_store_32,
                         3 => .load_store_64,
@@ -1049,14 +1049,16 @@ pub fn calcNumberOfPages(source_addr: u64, target_addr: u64) i21 {
     return pages;
 }
 
-pub fn calcPageOffset(target_addr: u64, kind: enum {
+const PageOffsetInstKind = enum {
     arithmetic,
     load_store_8,
     load_store_16,
     load_store_32,
     load_store_64,
     load_store_128,
-}) !u12 {
+};
+
+pub fn calcPageOffset(target_addr: u64, kind: PageOffsetInstKind) !u12 {
     const narrowed = @truncate(u12, target_addr);
     return switch (kind) {
         .arithmetic, .load_store_8 => narrowed,

--- a/src/MachO/Atom.zig
+++ b/src/MachO/Atom.zig
@@ -9,6 +9,7 @@ const macho = std.macho;
 const math = std.math;
 const mem = std.mem;
 const meta = std.meta;
+const trace = @import("../tracy.zig").trace;
 
 const Allocator = mem.Allocator;
 const Arch = std.Target.Cpu.Arch;
@@ -149,6 +150,9 @@ pub fn scanAtomRelocs(
     relocs: []align(1) const macho.relocation_info,
     reverse_lookup: []u32,
 ) !void {
+    const tracy = trace(@src());
+    defer tracy.end();
+
     const arch = macho_file.options.target.cpu_arch.?;
     const atom = macho_file.getAtom(atom_index);
     assert(atom.getFile() != null); // synthetic atoms do not have relocs
@@ -171,6 +175,9 @@ pub fn parseRelocTarget(
     rel: macho.relocation_info,
     reverse_lookup: []u32,
 ) MachO.SymbolWithLoc {
+    const tracy = trace(@src());
+    defer tracy.end();
+
     const atom = macho_file.getAtom(atom_index);
     const object = &macho_file.objects.items[atom.getFile().?];
 
@@ -196,6 +203,9 @@ pub fn parseRelocTarget(
 }
 
 pub fn getRelocTargetAtomIndex(macho_file: *MachO, rel: macho.relocation_info, target: SymbolWithLoc) ?AtomIndex {
+    const tracy = trace(@src());
+    defer tracy.end();
+
     const is_via_got = got: {
         switch (macho_file.options.target.cpu_arch.?) {
             .aarch64 => break :got switch (@intToEnum(macho.reloc_type_arm64, rel.r_type)) {
@@ -385,6 +395,9 @@ pub fn resolveRelocs(
     atom_relocs: []align(1) const macho.relocation_info,
     reverse_lookup: []u32,
 ) !void {
+    const tracy = trace(@src());
+    defer tracy.end();
+
     const arch = macho_file.options.target.cpu_arch.?;
     const atom = macho_file.getAtom(atom_index);
     assert(atom.getFile() != null); // synthetic atoms do not have relocs

--- a/src/MachO/Object.zig
+++ b/src/MachO/Object.zig
@@ -11,7 +11,7 @@ const macho = std.macho;
 const math = std.math;
 const mem = std.mem;
 const sort = std.sort;
-const trace = @import("../../tracy.zig").trace;
+const trace = @import("../tracy.zig").trace;
 
 const Allocator = mem.Allocator;
 const Atom = @import("Atom.zig");
@@ -62,6 +62,9 @@ pub fn deinit(self: *Object, gpa: Allocator) void {
 }
 
 pub fn parse(self: *Object, allocator: Allocator, cpu_arch: std.Target.Cpu.Arch) !void {
+    const tracy = trace(@src());
+    defer tracy.end();
+
     var stream = std.io.fixedBufferStream(self.contents);
     const reader = stream.reader();
 
@@ -279,6 +282,9 @@ fn sectionLessThanByAddress(ctx: void, lhs: SortedSection, rhs: SortedSection) b
 }
 
 pub fn splitIntoAtoms(self: *Object, macho_file: *MachO, object_id: u31) !void {
+    const tracy = trace(@src());
+    defer tracy.end();
+
     const gpa = macho_file.base.allocator;
 
     log.debug("splitting object({d}, {s}) into atoms", .{ object_id, self.name });

--- a/src/MachO/dead_strip.zig
+++ b/src/MachO/dead_strip.zig
@@ -169,23 +169,7 @@ fn markLive(
             .x86_64 => Atom.parseRelocTarget(macho_file, atom_index, rel, reverse_lookup),
             else => unreachable,
         };
-
         const target_sym = macho_file.getSymbol(target);
-
-        if (rel.r_extern == 0) {
-            // We are pessimistic and mark all atoms within the target section as live.
-            // TODO: this can be improved by marking only the relevant atoms.
-            const sect_id = target_sym.n_sect;
-            const object = macho_file.objects.items[target.getFile().?];
-            for (object.atoms.items) |other_atom_index| {
-                const other_atom = macho_file.getAtom(other_atom_index);
-                const other_sym = macho_file.getSymbol(other_atom.getSymbolWithLoc());
-                if (other_sym.n_sect == sect_id) {
-                    markLive(macho_file, other_atom_index, alive, reverse_lookups);
-                }
-            }
-            continue;
-        }
 
         if (target_sym.undf()) continue;
         if (target.getFile() == null) {

--- a/src/MachO/dead_strip.zig
+++ b/src/MachO/dead_strip.zig
@@ -4,6 +4,7 @@ const log = std.log.scoped(.dead_strip);
 const macho = std.macho;
 const math = std.math;
 const mem = std.mem;
+const trace = @import("../tracy.zig").trace;
 
 const Allocator = mem.Allocator;
 const AtomIndex = MachO.AtomIndex;
@@ -14,6 +15,9 @@ const SymbolWithLoc = MachO.SymbolWithLoc;
 const AtomTable = std.AutoHashMap(AtomIndex, void);
 
 pub fn gcAtoms(macho_file: *MachO, reverse_lookups: [][]u32) Allocator.Error!void {
+    const tracy = trace(@src());
+    defer tracy.end();
+
     const gpa = macho_file.base.allocator;
 
     var arena = std.heap.ArenaAllocator.init(gpa);

--- a/src/MachO/dead_strip.zig
+++ b/src/MachO/dead_strip.zig
@@ -35,6 +35,9 @@ pub fn gcAtoms(macho_file: *MachO, reverse_lookups: [][]u32) Allocator.Error!voi
 }
 
 fn collectRoots(macho_file: *MachO, roots: *AtomTable) !void {
+    const tracy = trace(@src());
+    defer tracy.end();
+
     const output_mode = macho_file.options.output_mode;
 
     log.debug("collecting roots", .{});
@@ -135,6 +138,9 @@ fn markLive(
     alive: *AtomTable,
     reverse_lookups: [][]u32,
 ) void {
+    const tracy = trace(@src());
+    defer tracy.end();
+
     if (alive.contains(atom_index)) return;
 
     const atom = macho_file.getAtom(atom_index);
@@ -203,6 +209,9 @@ fn markLive(
 }
 
 fn refersLive(macho_file: *MachO, atom_index: AtomIndex, alive: AtomTable, reverse_lookups: [][]u32) bool {
+    const tracy = trace(@src());
+    defer tracy.end();
+
     const atom = macho_file.getAtom(atom_index);
     const sym_loc = atom.getSymbolWithLoc();
 
@@ -247,6 +256,9 @@ fn refersLive(macho_file: *MachO, atom_index: AtomIndex, alive: AtomTable, rever
 }
 
 fn mark(macho_file: *MachO, roots: AtomTable, alive: *AtomTable, reverse_lookups: [][]u32) void {
+    const tracy = trace(@src());
+    defer tracy.end();
+
     var it = roots.keyIterator();
     while (it.next()) |root| {
         markLive(macho_file, root.*, alive, reverse_lookups);
@@ -282,6 +294,9 @@ fn mark(macho_file: *MachO, roots: AtomTable, alive: *AtomTable, reverse_lookups
 }
 
 fn prune(macho_file: *MachO, alive: AtomTable) void {
+    const tracy = trace(@src());
+    defer tracy.end();
+
     log.debug("pruning dead atoms", .{});
     for (macho_file.objects.items) |*object| {
         var i: usize = 0;

--- a/src/Zld.zig
+++ b/src/Zld.zig
@@ -5,6 +5,7 @@ const fs = std.fs;
 const io = std.io;
 const mem = std.mem;
 const process = std.process;
+const trace = @import("tracy.zig").trace;
 
 const Allocator = mem.Allocator;
 const CrossTarget = std.zig.CrossTarget;
@@ -74,6 +75,9 @@ pub const MainCtx = struct {
 };
 
 pub fn main(tag: Tag, ctx: MainCtx) !void {
+    const tracy = trace(@src());
+    defer tracy.end();
+
     var arena_allocator = std.heap.ArenaAllocator.init(ctx.gpa);
     defer arena_allocator.deinit();
     const arena = arena_allocator.allocator();

--- a/src/tracy.zig
+++ b/src/tracy.zig
@@ -1,0 +1,308 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const build_options = @import("build_options");
+
+pub const enable = if (builtin.is_test) false else build_options.enable_tracy;
+pub const enable_allocation = false; // enable and build_options.enable_tracy_allocation;
+pub const enable_callstack = false; //enable and build_options.enable_tracy_callstack;
+
+// TODO: make this configurable
+const callstack_depth = 10;
+
+const ___tracy_c_zone_context = extern struct {
+    id: u32,
+    active: c_int,
+
+    pub inline fn end(self: @This()) void {
+        ___tracy_emit_zone_end(self);
+    }
+
+    pub inline fn addText(self: @This(), text: []const u8) void {
+        ___tracy_emit_zone_text(self, text.ptr, text.len);
+    }
+
+    pub inline fn setName(self: @This(), name: []const u8) void {
+        ___tracy_emit_zone_name(self, name.ptr, name.len);
+    }
+
+    pub inline fn setColor(self: @This(), color: u32) void {
+        ___tracy_emit_zone_color(self, color);
+    }
+
+    pub inline fn setValue(self: @This(), value: u64) void {
+        ___tracy_emit_zone_value(self, value);
+    }
+};
+
+pub const Ctx = if (enable) ___tracy_c_zone_context else struct {
+    pub inline fn end(self: @This()) void {
+        _ = self;
+    }
+
+    pub inline fn addText(self: @This(), text: []const u8) void {
+        _ = self;
+        _ = text;
+    }
+
+    pub inline fn setName(self: @This(), name: []const u8) void {
+        _ = self;
+        _ = name;
+    }
+
+    pub inline fn setColor(self: @This(), color: u32) void {
+        _ = self;
+        _ = color;
+    }
+
+    pub inline fn setValue(self: @This(), value: u64) void {
+        _ = self;
+        _ = value;
+    }
+};
+
+pub inline fn trace(comptime src: std.builtin.SourceLocation) Ctx {
+    if (!enable) return .{};
+
+    if (enable_callstack) {
+        return ___tracy_emit_zone_begin_callstack(&.{
+            .name = null,
+            .function = src.fn_name.ptr,
+            .file = src.file.ptr,
+            .line = src.line,
+            .color = 0,
+        }, callstack_depth, 1);
+    } else {
+        return ___tracy_emit_zone_begin(&.{
+            .name = null,
+            .function = src.fn_name.ptr,
+            .file = src.file.ptr,
+            .line = src.line,
+            .color = 0,
+        }, 1);
+    }
+}
+
+pub inline fn traceNamed(comptime src: std.builtin.SourceLocation, comptime name: [:0]const u8) Ctx {
+    if (!enable) return .{};
+
+    if (enable_callstack) {
+        return ___tracy_emit_zone_begin_callstack(&.{
+            .name = name.ptr,
+            .function = src.fn_name.ptr,
+            .file = src.file.ptr,
+            .line = src.line,
+            .color = 0,
+        }, callstack_depth, 1);
+    } else {
+        return ___tracy_emit_zone_begin(&.{
+            .name = name.ptr,
+            .function = src.fn_name.ptr,
+            .file = src.file.ptr,
+            .line = src.line,
+            .color = 0,
+        }, 1);
+    }
+}
+
+pub fn tracyAllocator(allocator: std.mem.Allocator) TracyAllocator(null) {
+    return TracyAllocator(null).init(allocator);
+}
+
+pub fn TracyAllocator(comptime name: ?[:0]const u8) type {
+    return struct {
+        parent_allocator: std.mem.Allocator,
+
+        const Self = @This();
+
+        pub fn init(parent_allocator: std.mem.Allocator) Self {
+            return .{
+                .parent_allocator = parent_allocator,
+            };
+        }
+
+        pub fn allocator(self: *Self) std.mem.Allocator {
+            return std.mem.Allocator.init(self, allocFn, resizeFn, freeFn);
+        }
+
+        fn allocFn(self: *Self, len: usize, ptr_align: u29, len_align: u29, ret_addr: usize) std.mem.Allocator.Error![]u8 {
+            const result = self.parent_allocator.rawAlloc(len, ptr_align, len_align, ret_addr);
+            if (result) |data| {
+                if (data.len != 0) {
+                    if (name) |n| {
+                        allocNamed(data.ptr, data.len, n);
+                    } else {
+                        alloc(data.ptr, data.len);
+                    }
+                }
+            } else |_| {
+                messageColor("allocation failed", 0xFF0000);
+            }
+            return result;
+        }
+
+        fn resizeFn(self: *Self, buf: []u8, buf_align: u29, new_len: usize, len_align: u29, ret_addr: usize) ?usize {
+            if (self.parent_allocator.rawResize(buf, buf_align, new_len, len_align, ret_addr)) |resized_len| {
+                if (name) |n| {
+                    freeNamed(buf.ptr, n);
+                    allocNamed(buf.ptr, resized_len, n);
+                } else {
+                    free(buf.ptr);
+                    alloc(buf.ptr, resized_len);
+                }
+
+                return resized_len;
+            }
+
+            // during normal operation the compiler hits this case thousands of times due to this
+            // emitting messages for it is both slow and causes clutter
+            return null;
+        }
+
+        fn freeFn(self: *Self, buf: []u8, buf_align: u29, ret_addr: usize) void {
+            self.parent_allocator.rawFree(buf, buf_align, ret_addr);
+            // this condition is to handle free being called on an empty slice that was never even allocated
+            // example case: `std.process.getSelfExeSharedLibPaths` can return `&[_][:0]u8{}`
+            if (buf.len != 0) {
+                if (name) |n| {
+                    freeNamed(buf.ptr, n);
+                } else {
+                    free(buf.ptr);
+                }
+            }
+        }
+    };
+}
+
+// This function only accepts comptime known strings, see `messageCopy` for runtime strings
+pub inline fn message(comptime msg: [:0]const u8) void {
+    if (!enable) return;
+    ___tracy_emit_messageL(msg.ptr, if (enable_callstack) callstack_depth else 0);
+}
+
+// This function only accepts comptime known strings, see `messageColorCopy` for runtime strings
+pub inline fn messageColor(comptime msg: [:0]const u8, color: u32) void {
+    if (!enable) return;
+    ___tracy_emit_messageLC(msg.ptr, color, if (enable_callstack) callstack_depth else 0);
+}
+
+pub inline fn messageCopy(msg: []const u8) void {
+    if (!enable) return;
+    ___tracy_emit_message(msg.ptr, msg.len, if (enable_callstack) callstack_depth else 0);
+}
+
+pub inline fn messageColorCopy(msg: [:0]const u8, color: u32) void {
+    if (!enable) return;
+    ___tracy_emit_messageC(msg.ptr, msg.len, color, if (enable_callstack) callstack_depth else 0);
+}
+
+pub inline fn frameMark() void {
+    if (!enable) return;
+    ___tracy_emit_frame_mark(null);
+}
+
+pub inline fn frameMarkNamed(comptime name: [:0]const u8) void {
+    if (!enable) return;
+    ___tracy_emit_frame_mark(name.ptr);
+}
+
+pub inline fn namedFrame(comptime name: [:0]const u8) Frame(name) {
+    frameMarkStart(name);
+    return .{};
+}
+
+pub fn Frame(comptime name: [:0]const u8) type {
+    return struct {
+        pub fn end(_: @This()) void {
+            frameMarkEnd(name);
+        }
+    };
+}
+
+inline fn frameMarkStart(comptime name: [:0]const u8) void {
+    if (!enable) return;
+    ___tracy_emit_frame_mark_start(name.ptr);
+}
+
+inline fn frameMarkEnd(comptime name: [:0]const u8) void {
+    if (!enable) return;
+    ___tracy_emit_frame_mark_end(name.ptr);
+}
+
+extern fn ___tracy_emit_frame_mark_start(name: [*:0]const u8) void;
+extern fn ___tracy_emit_frame_mark_end(name: [*:0]const u8) void;
+
+inline fn alloc(ptr: [*]u8, len: usize) void {
+    if (!enable) return;
+
+    if (enable_callstack) {
+        ___tracy_emit_memory_alloc_callstack(ptr, len, callstack_depth, 0);
+    } else {
+        ___tracy_emit_memory_alloc(ptr, len, 0);
+    }
+}
+
+inline fn allocNamed(ptr: [*]u8, len: usize, comptime name: [:0]const u8) void {
+    if (!enable) return;
+
+    if (enable_callstack) {
+        ___tracy_emit_memory_alloc_callstack_named(ptr, len, callstack_depth, 0, name.ptr);
+    } else {
+        ___tracy_emit_memory_alloc_named(ptr, len, 0, name.ptr);
+    }
+}
+
+inline fn free(ptr: [*]u8) void {
+    if (!enable) return;
+
+    if (enable_callstack) {
+        ___tracy_emit_memory_free_callstack(ptr, callstack_depth, 0);
+    } else {
+        ___tracy_emit_memory_free(ptr, 0);
+    }
+}
+
+inline fn freeNamed(ptr: [*]u8, comptime name: [:0]const u8) void {
+    if (!enable) return;
+
+    if (enable_callstack) {
+        ___tracy_emit_memory_free_callstack_named(ptr, callstack_depth, 0, name.ptr);
+    } else {
+        ___tracy_emit_memory_free_named(ptr, 0, name.ptr);
+    }
+}
+
+extern fn ___tracy_emit_zone_begin(
+    srcloc: *const ___tracy_source_location_data,
+    active: c_int,
+) ___tracy_c_zone_context;
+extern fn ___tracy_emit_zone_begin_callstack(
+    srcloc: *const ___tracy_source_location_data,
+    depth: c_int,
+    active: c_int,
+) ___tracy_c_zone_context;
+extern fn ___tracy_emit_zone_text(ctx: ___tracy_c_zone_context, txt: [*]const u8, size: usize) void;
+extern fn ___tracy_emit_zone_name(ctx: ___tracy_c_zone_context, txt: [*]const u8, size: usize) void;
+extern fn ___tracy_emit_zone_color(ctx: ___tracy_c_zone_context, color: u32) void;
+extern fn ___tracy_emit_zone_value(ctx: ___tracy_c_zone_context, value: u64) void;
+extern fn ___tracy_emit_zone_end(ctx: ___tracy_c_zone_context) void;
+extern fn ___tracy_emit_memory_alloc(ptr: *const anyopaque, size: usize, secure: c_int) void;
+extern fn ___tracy_emit_memory_alloc_callstack(ptr: *const anyopaque, size: usize, depth: c_int, secure: c_int) void;
+extern fn ___tracy_emit_memory_free(ptr: *const anyopaque, secure: c_int) void;
+extern fn ___tracy_emit_memory_free_callstack(ptr: *const anyopaque, depth: c_int, secure: c_int) void;
+extern fn ___tracy_emit_memory_alloc_named(ptr: *const anyopaque, size: usize, secure: c_int, name: [*:0]const u8) void;
+extern fn ___tracy_emit_memory_alloc_callstack_named(ptr: *const anyopaque, size: usize, depth: c_int, secure: c_int, name: [*:0]const u8) void;
+extern fn ___tracy_emit_memory_free_named(ptr: *const anyopaque, secure: c_int, name: [*:0]const u8) void;
+extern fn ___tracy_emit_memory_free_callstack_named(ptr: *const anyopaque, depth: c_int, secure: c_int, name: [*:0]const u8) void;
+extern fn ___tracy_emit_message(txt: [*]const u8, size: usize, callstack: c_int) void;
+extern fn ___tracy_emit_messageL(txt: [*:0]const u8, callstack: c_int) void;
+extern fn ___tracy_emit_messageC(txt: [*]const u8, size: usize, color: u32, callstack: c_int) void;
+extern fn ___tracy_emit_messageLC(txt: [*:0]const u8, color: u32, callstack: c_int) void;
+extern fn ___tracy_emit_frame_mark(name: ?[*:0]const u8) void;
+
+const ___tracy_source_location_data = extern struct {
+    name: ?[*:0]const u8,
+    function: [*:0]const u8,
+    file: [*:0]const u8,
+    line: u32,
+    color: u32,
+};


### PR DESCRIPTION
Prior to the regression, we would unnecessarily spin in `markLive` routine when dead stripping due to inability to handle target atoms described by a hard-coded in-section address (combination of `r_extern == 0` and `r_pcrel == 0` which normally occurs in `X86_64_RELOC_UNSIGNED`). This is now fixed by caching sorted source symbols by address per object and finding the containing atom of this type of relocation, and marking it live.

**EDIT:** I messed up the initial patch as I didn't take into account `r_extern == 0` and `r_pcrel == 1` which normally occurs in `X86_64_RELOC_SIGNED`, and then I made a very difficult to debug typo in the new code, but finally we are here. I've therefore updates the measurements below.

The link time of `stage3` with dead stripping has now been reduced by 1 second making `zld` just ~~1.39x~~ 1.40x slower than `lld` and faster than `ld64`:

```
❯ hyperfine ./zld ./lld ./ld64 --warmup 5
Benchmark 1: ./zld
  Time (mean ± σ):      2.300 s ±  0.013 s    [User: 1.484 s, System: 0.797 s]
  Range (min … max):    2.284 s …  2.321 s    10 runs
 
Benchmark 2: ./lld
  Time (mean ± σ):      1.639 s ±  0.010 s    [User: 1.655 s, System: 0.624 s]
  Range (min … max):    1.627 s …  1.656 s    10 runs
 
Benchmark 3: ./ld64
  Time (mean ± σ):      2.682 s ±  0.060 s    [User: 3.638 s, System: 0.721 s]
  Range (min … max):    2.627 s …  2.802 s    10 runs
 
Summary
  './lld' ran
    1.40 ± 0.01 times faster than './zld'
    1.64 ± 0.04 times faster than './ld64'
```