### PR TITLE
Various wasm-linker improvements

### DIFF
--- a/src/Wasm.zig
+++ b/src/Wasm.zig
@@ -1066,9 +1066,13 @@ fn allocateAtoms(wasm: *Wasm) !void {
         var atom: *Atom = entry.value_ptr.*.getFirst();
         var offset: u32 = 0;
         while (true) {
+            const symbol_loc = atom.symbolLoc();
+            if (!wasm.resolved_symbols.contains(symbol_loc)) {
+                atom = atom.next orelse break;
+                continue;
+            }
             offset = std.mem.alignForwardGeneric(u32, offset, atom.alignment);
             atom.offset = offset;
-            const symbol_loc = atom.symbolLoc();
             log.debug("Atom '{s}' allocated from 0x{x:0>8} to 0x{x:0>8} size={d}", .{
                 symbol_loc.getName(wasm),
                 offset,

--- a/src/Wasm/Archive.zig
+++ b/src/Wasm/Archive.zig
@@ -18,7 +18,7 @@ header: ar_hdr = undefined,
 /// This is stored as a single slice of bytes, as the header-names
 /// point to the character index of a file name, rather than the index
 /// in the list.
-long_file_names: []const u8 = undefined,
+long_file_names: []const u8 = &.{},
 
 /// Parsed table of contents.
 /// Each symbol name points to a list of all definition

--- a/src/Wasm/Archive.zig
+++ b/src/Wasm/Archive.zig
@@ -157,13 +157,12 @@ fn parseTableOfContents(archive: *Archive, allocator: Allocator, reader: anytype
     };
 
     var i: usize = 0;
-    while (i < sym_tab.len) {
-        const string = mem.sliceTo(sym_tab[i..], 0);
-        if (string.len == 0) {
-            i += 1;
-            continue;
-        }
-        i += string.len;
+    var pos: usize = 0;
+    while (i < num_symbols) : (i += 1) {
+        const string = mem.sliceTo(sym_tab[pos..], 0);
+        pos += string.len + 1;
+        if (string.len == 0) continue;
+
         const name = try allocator.dupe(u8, string);
         errdefer allocator.free(name);
         const gop = try archive.toc.getOrPut(allocator, name);
@@ -172,7 +171,7 @@ fn parseTableOfContents(archive: *Archive, allocator: Allocator, reader: anytype
         } else {
             gop.value_ptr.* = .{};
         }
-        try gop.value_ptr.append(allocator, symbol_positions[gop.index]);
+        try gop.value_ptr.append(allocator, symbol_positions[i]);
     }
 }
 

--- a/src/Wasm/Atom.zig
+++ b/src/Wasm/Atom.zig
@@ -165,7 +165,10 @@ fn relocationValue(atom: *Atom, relocation: types.Relocation, wasm_bin: *const W
         .R_WASM_MEMORY_ADDR_SLEB,
         .R_WASM_MEMORY_ADDR_SLEB64,
         => {
-            std.debug.assert(symbol.tag == .data and !symbol.isUndefined());
+            std.debug.assert(symbol.tag == .data);
+            if (symbol.isUndefined()) {
+                return 0;
+            }
             const merge_segment = wasm_bin.options.merge_data_segments;
             const target_atom = wasm_bin.symbol_atom.get(target_loc).?;
             const segment_info = wasm_bin.objects.items[target_atom.file].segment_info;

--- a/src/Wasm/Atom.zig
+++ b/src/Wasm/Atom.zig
@@ -152,10 +152,8 @@ fn relocationValue(atom: *Atom, relocation: types.Relocation, wasm_bin: *const W
         .R_WASM_TABLE_INDEX_SLEB64,
         => return wasm_bin.elements.indirect_functions.get(target_loc) orelse 0,
         .R_WASM_TYPE_INDEX_LEB => {
-            if (symbol.isUndefined()) {
-                return wasm_bin.imports.imported_functions.values()[symbol.index].type;
-            }
-            return wasm_bin.functions.items.items[symbol.index].type_index;
+            const original_type = wasm_bin.objects.items[atom.file].func_types[relocation.index];
+            return wasm_bin.func_types.find(original_type).?;
         },
         .R_WASM_GLOBAL_INDEX_I32,
         .R_WASM_GLOBAL_INDEX_LEB,

--- a/src/Wasm/emit_wasm.zig
+++ b/src/Wasm/emit_wasm.zig
@@ -111,8 +111,10 @@ pub fn emit(wasm: *Wasm) !void {
         defer sorted_atoms.deinit();
 
         while (true) {
-            atom.resolveRelocs(wasm);
-            sorted_atoms.appendAssumeCapacity(atom);
+            if (wasm.resolved_symbols.contains(atom.symbolLoc())) {
+                atom.resolveRelocs(wasm);
+                sorted_atoms.appendAssumeCapacity(atom);
+            }
             atom = atom.next orelse break;
         }
 
@@ -151,6 +153,10 @@ pub fn emit(wasm: *Wasm) !void {
 
             var current_offset: u32 = 0;
             while (true) {
+                if (!wasm.resolved_symbols.contains(atom.symbolLoc())) {
+                    atom = atom.next orelse break;
+                    continue;
+                }
                 atom.resolveRelocs(wasm);
                 // TODO: Verify if this is faster than allocating segment's size
                 // Setting all zeroes, memcopy all segments and then writing.


### PR DESCRIPTION
- export data symbols as global
- Fix archive table of symbols parsing
- Fix type index relocations
- Fix relocations for atoms with aliases
