### PR TITLE
bump CI dependency versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
     - if: matrix.os == 'windows'
       run: git config --global core.autocrlf false
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
-    - uses: goto-bus-stop/setup-zig@v1
+    - uses: goto-bus-stop/setup-zig@v2
       with:
         version: master
     - run: zig version


### PR DESCRIPTION
The current dependencies are using node12, which is deprecated and will no longer be supported from summer 2023. The new versions are using node16 instead.
