### PR TITLE
misc fixes

### DIFF
--- a/src/Wasm.zig
+++ b/src/Wasm.zig
@@ -754,7 +754,7 @@ fn setupExports(wasm: *Wasm) !void {
             const segment_index = wasm.data_segments.get(segment_name).?;
             const segment = wasm.segments.items[segment_index];
             const addr_value = @bitCast(i32, atom.offset + segment.offset);
-            const offset = wasm.globals.count() + wasm.imports.globalCount();
+            const offset = wasm.imports.globalCount();
             const global_index = try wasm.globals.append(wasm.base.allocator, offset, .{
                 .global_type = .{ .valtype = .i32, .mutable = false },
                 .init = .{ .i32_const = addr_value },

--- a/src/Wasm/Options.zig
+++ b/src/Wasm/Options.zig
@@ -74,7 +74,7 @@ pub fn parseArgs(arena: Allocator, context: Zld.MainCtx) !Options {
     const args = context.args;
     var positionals = std.ArrayList([]const u8).init(arena);
     var entry_name: ?[]const u8 = null;
-    var global_base: ?u32 = 1024;
+    var global_base: ?u32 = null;
     var import_memory: bool = false;
     var import_table: bool = false;
     var initial_memory: ?u32 = null;

--- a/src/Wasm/Options.zig
+++ b/src/Wasm/Options.zig
@@ -27,6 +27,7 @@ const usage =
     \\--stack-first                      Place stack at start of linear memory instead of after data
     \\--stack-size=<value>               Specifies the stack size in bytes
     \\--features=<value>                 Comma-delimited list of used features, inferred by object files if unset
+    \\--strip                            Strip all debug information and symbol names
 ;
 
 /// Result path of the binary
@@ -61,6 +62,9 @@ stack_size: ?u32 = null,
 /// Comma-delimited list of features to use.
 /// When empty, the used features are inferred from the objects instead.
 features: []const u8,
+/// Strips all debug information and optional sections such as symbol names,
+/// and the 'producers' section.
+strip: bool = false,
 
 pub fn parseArgs(arena: Allocator, context: Zld.MainCtx) !Options {
     if (context.args.len == 0) {
@@ -81,6 +85,7 @@ pub fn parseArgs(arena: Allocator, context: Zld.MainCtx) !Options {
     var stack_first = false;
     var stack_size: ?u32 = null;
     var features: ?[]const u8 = null;
+    var strip: ?bool = null;
 
     var i: usize = 0;
     while (i < args.len) : (i += 1) {
@@ -142,6 +147,8 @@ pub fn parseArgs(arena: Allocator, context: Zld.MainCtx) !Options {
             const index = mem.indexOfScalar(u8, arg, '=') orelse context.printFailure("Missing '=' symbol and value for features list", .{});
             features = arg[index + 1 ..];
             i += 1;
+        } else if (mem.eql(u8, arg, "--strip")) {
+            strip = true;
         } else {
             try positionals.append(arg);
         }
@@ -172,5 +179,6 @@ pub fn parseArgs(arena: Allocator, context: Zld.MainCtx) !Options {
         .stack_first = stack_first,
         .stack_size = stack_size,
         .features = features orelse &.{},
+        .strip = strip orelse false,
     };
 }

--- a/src/Wasm/Options.zig
+++ b/src/Wasm/Options.zig
@@ -14,6 +14,7 @@ const usage =
     \\
     \\Options:
     \\-h, --help                         Print this help and exit
+    \\--debug-log [scope]                Turn on debugging logs for [scope] (requires zld compiled with -Dlog)
     \\-o [path]                          Output path of the binary
     \\--entry <entry>                    Name of entry point symbol
     \\--global-base=<value>              Value from where the global data will start
@@ -86,6 +87,10 @@ pub fn parseArgs(arena: Allocator, context: Zld.MainCtx) !Options {
         const arg = args[i];
         if (mem.eql(u8, arg, "-h") or mem.eql(u8, arg, "--help")) {
             context.printSuccess(usage, .{context.cmd});
+        } else if (mem.eql(u8, arg, "--debug-log")) {
+            if (i + 1 >= args.len) context.printFailure("Missing scope for debug log", .{});
+            i += 1;
+            try context.log_scopes.append(args[i]);
         } else if (mem.eql(u8, arg, "--entry")) {
             if (i + 1 >= args.len) context.printFailure("Missing entry name argument", .{});
             entry_name = args[i + 1];

--- a/src/Wasm/Symbol.zig
+++ b/src/Wasm/Symbol.zig
@@ -137,10 +137,9 @@ pub fn isNoStrip(symbol: Symbol) bool {
 
 pub fn isExported(symbol: Symbol) bool {
     if (symbol.isUndefined() or symbol.isLocal()) return false;
-    if (symbol.isHidden()) return false;
-    if (symbol.hasFlag(.WASM_SYM_EXPORTED)) return true;
-    if (symbol.hasFlag(.WASM_SYM_BINDING_WEAK)) return false;
-    return true;
+    // TODO: support dynamic flag and then automatically export
+    // symbols which are not hidden
+    return symbol.hasFlag(.WASM_SYM_EXPORTED);
 }
 
 pub fn isWeak(symbol: Symbol) bool {

--- a/src/Wasm/emit_wasm.zig
+++ b/src/Wasm/emit_wasm.zig
@@ -337,33 +337,40 @@ fn emitType(type_entry: std.wasm.Type, writer: anytype) !void {
 
 fn emitImportSymbol(wasm: *const Wasm, sym_loc: Wasm.SymbolWithLoc, writer: anytype) !void {
     const symbol = sym_loc.getSymbol(wasm).*;
-    var import: std.wasm.Import = .{
-        .module_name = undefined,
-        .name = sym_loc.getName(wasm),
-        .kind = undefined,
-    };
 
-    switch (symbol.tag) {
-        .function => {
+    const import: std.wasm.Import = switch (symbol.tag) {
+        .function => import: {
             const value = wasm.imports.imported_functions.values()[symbol.index];
+            const key = wasm.imports.imported_functions.keys()[symbol.index];
             std.debug.assert(value.index == symbol.index);
-            import.kind = .{ .function = value.type };
-            import.module_name = wasm.imports.imported_functions.keys()[symbol.index].module_name;
+            break :import .{
+                .kind = .{ .function = value.type },
+                .module_name = key.module_name,
+                .name = key.name,
+            };
         },
-        .global => {
+        .global => import: {
             const value = wasm.imports.imported_globals.values()[symbol.index];
+            const key = wasm.imports.imported_globals.keys()[symbol.index];
             std.debug.assert(value.index == symbol.index);
-            import.kind = .{ .global = value.global };
-            import.module_name = wasm.imports.imported_globals.keys()[symbol.index].module_name;
+            break :import .{
+                .kind = .{ .global = value.global },
+                .module_name = key.module_name,
+                .name = key.name,
+            };
         },
-        .table => {
+        .table => import: {
             const value = wasm.imports.imported_tables.values()[symbol.index];
+            const key = wasm.imports.imported_tables.keys()[symbol.index];
             std.debug.assert(value.index == symbol.index);
-            import.kind = .{ .table = value.table };
-            import.module_name = wasm.imports.imported_tables.keys()[symbol.index].module_name;
+            break :import .{
+                .kind = .{ .table = value.table },
+                .module_name = key.module_name,
+                .name = key.name,
+            };
         },
         else => unreachable,
-    }
+    };
 
     try emitImport(import, writer);
 }

--- a/src/Wasm/emit_wasm.zig
+++ b/src/Wasm/emit_wasm.zig
@@ -452,9 +452,9 @@ fn emitElement(wasm: *Wasm, writer: anytype) !void {
     // Start the function table at index 1
     try emitInitExpression(.{ .i32_const = 1 }, writer);
     try leb.writeULEB128(writer, wasm.elements.functionCount());
-    for (wasm.elements.indirect_functions.keys()) |sym_loc| {
-        const symbol = sym_loc.getSymbol(wasm);
-        try leb.writeULEB128(writer, symbol.index);
+    var it = wasm.elements.indirect_functions.keyIterator();
+    while (it.next()) |key_ptr| {
+        try leb.writeULEB128(writer, key_ptr.*.getSymbol(wasm).index);
     }
 }
 

--- a/src/Wasm/sections.zig
+++ b/src/Wasm/sections.zig
@@ -15,19 +15,24 @@ pub const Functions = struct {
     /// Holds the list of function type indexes.
     /// The list is built from merging all defined functions into this single list.
     /// Once appended, it becomes immutable and should not be mutated outside this list.
-    items: std.ArrayListUnmanaged(std.wasm.Func) = .{},
+    items: std.AutoArrayHashMapUnmanaged(struct { file: u16, index: u32 }, std.wasm.Func) = .{},
 
     /// Adds a new function to the section while also setting the function index
     /// of the `Func` itself.
-    pub fn append(self: *Functions, gpa: Allocator, offset: u32, func: std.wasm.Func) !u32 {
-        const index = offset + self.count();
-        try self.items.append(gpa, func);
-        return index;
+    pub fn append(self: *Functions, gpa: Allocator, ref: struct { file: u16, index: u32 }, offset: u32, func: std.wasm.Func) !u32 {
+        const gop = try self.items.getOrPut(
+            gpa,
+            .{ .file = ref.file, .index = ref.index },
+        );
+        if (!gop.found_existing) {
+            gop.value_ptr.* = func;
+        }
+        return @intCast(u32, gop.index) + offset;
     }
 
     /// Returns the count of entires within the function section
     pub fn count(self: *Functions) u32 {
-        return @intCast(u32, self.items.items.len);
+        return @intCast(u32, self.items.count());
     }
 
     pub fn deinit(self: *Functions, gpa: Allocator) void {
@@ -355,17 +360,6 @@ pub const Elements = struct {
     /// A list of symbols for indirect function calls where the key
     /// represents the symbol location, and the value represents the index into the table.
     indirect_functions: std.AutoArrayHashMapUnmanaged(Wasm.SymbolWithLoc, u32) = .{},
-
-    /// Appends a function symbol to the list of indirect function calls.
-    /// The table index will be set on the symbol, based on the length
-    ///
-    /// Asserts symbol represents a function.
-    pub fn appendSymbol(self: *Elements, gpa: Allocator, symbol_loc: Wasm.SymbolWithLoc) !void {
-        const gop = try self.indirect_functions.getOrPut(gpa, symbol_loc);
-        if (gop.found_existing) return;
-        // start at index 1 so the index '0' is an invalid function pointer
-        gop.value_ptr.* = self.functionCount() + 1;
-    }
 
     pub fn functionCount(self: Elements) u32 {
         return @intCast(u32, self.indirect_functions.count());

--- a/src/Wasm/sections.zig
+++ b/src/Wasm/sections.zig
@@ -285,9 +285,7 @@ pub const Types = struct {
     /// otherwise, returns `null`.
     pub fn find(self: Types, func_type: std.wasm.Type) ?u32 {
         return for (self.items.items) |ty, index| {
-            if (std.mem.eql(std.wasm.Valtype, ty.params, func_type.params) and
-                std.mem.eql(std.wasm.Valtype, ty.returns, func_type.returns))
-            {
+            if (ty.eql(func_type)) {
                 return @intCast(u32, index);
             }
         } else null;
@@ -359,7 +357,7 @@ pub const Exports = struct {
 pub const Elements = struct {
     /// A list of symbols for indirect function calls where the key
     /// represents the symbol location, and the value represents the index into the table.
-    indirect_functions: std.AutoArrayHashMapUnmanaged(Wasm.SymbolWithLoc, u32) = .{},
+    indirect_functions: std.AutoHashMapUnmanaged(Wasm.SymbolWithLoc, u32) = .{},
 
     pub fn functionCount(self: Elements) u32 {
         return @intCast(u32, self.indirect_functions.count());

--- a/src/Wasm/sections.zig
+++ b/src/Wasm/sections.zig
@@ -109,7 +109,7 @@ pub const Imports = struct {
         const symbol = &object.symtable[sym_with_loc.sym_index];
         const import = object.findImport(symbol.tag.externalType(), symbol.index);
         const module_name = object.string_table.get(import.module_name);
-        const import_name = object.string_table.get(symbol.name);
+        const import_name = object.string_table.get(import.name);
 
         switch (symbol.tag) {
             .function => {


### PR DESCRIPTION
Implements several fixes to allow the linker to successfully link Zig's behavior test suite with libc and compiler_rt.

- fix index to global for exported data symbols
- fully support indirect function table
- emit the correct import name
- improve function pointer support
- Implement `--strip` flag
- fix table limits
