### PR TITLE
Support linking with WASI-libc

### DIFF
--- a/src/Wasm.zig
+++ b/src/Wasm.zig
@@ -374,6 +374,7 @@ pub fn flush(wasm: *Wasm) !void {
         try wasm.resolveSymbolsInObject(@intCast(u16, obj_idx));
     }
     try wasm.resolveSymbolsInArchives();
+    try wasm.resolveLazySymbols();
     try wasm.checkUndefinedSymbols();
     for (wasm.objects.items) |*object, obj_idx| {
         try object.parseIntoAtoms(@intCast(u16, obj_idx), wasm);
@@ -636,6 +637,25 @@ fn resolveSymbolsInArchives(wasm: *Wasm) !void {
     }
 }
 
+/// Creates synthetic linker-symbols, but only if they are being referenced from
+/// any object file. For instance, the `__heap_base` symbol will only be created,
+/// if one or multiple undefined references exist. When none exist, the symbol will
+/// not be created, ensuring we don't unneccesarily emit unreferenced symbols.
+fn resolveLazySymbols(wasm: *Wasm) !void {
+    if (wasm.undefs.fetchSwapRemove("__heap_base")) |kv| {
+        const loc = try wasm.createSyntheticSymbol("__heap_base", .data);
+        try wasm.discarded.putNoClobber(wasm.base.allocator, kv.value, loc);
+        _ = wasm.resolved_symbols.swapRemove(loc); // we don't want to emit this symbol, only use it for relocations.
+
+        const atom = try Atom.create(wasm.base.allocator);
+        atom.size = 0;
+        atom.sym_index = loc.sym_index;
+        atom.file = null;
+        // va/offset will be set during `setupMemory`
+        try wasm.symbol_atom.put(wasm.base.allocator, loc, atom);
+    }
+}
+
 /// From a given symbol location, returns its `wasm.GlobalType`.
 /// Asserts the Symbol represents a global.
 fn getGlobalType(wasm: *const Wasm, loc: SymbolWithLoc) std.wasm.GlobalType {
@@ -691,9 +711,8 @@ fn mergeSections(wasm: *Wasm) !void {
     const function_pointers = wasm.elements.functionCount();
     if (function_pointers > 0 and !wasm.options.import_table) {
         log.debug("Appending indirect function table", .{});
-        const offset = wasm.string_table.getOffset("__indirect_function_table").?;
-        const sym_with_loc = wasm.global_symbols.get(offset).?;
-        const symbol = sym_with_loc.getSymbol(wasm);
+        const loc = wasm.findGlobalSymbol("__indirect_function_table").?;
+        const symbol = loc.getSymbol(wasm);
         symbol.index = try wasm.tables.append(
             wasm.base.allocator,
             wasm.imports.tableCount(),
@@ -798,11 +817,7 @@ fn setupExports(wasm: *Wasm) !void {
         defer failed_exports.deinit();
 
         for (wasm.options.exports) |export_name| {
-            const name_index = wasm.string_table.getOffset(export_name) orelse {
-                failed_exports.appendAssumeCapacity(export_name);
-                continue;
-            };
-            const loc = wasm.global_symbols.get(name_index) orelse {
+            const loc = wasm.findGlobalSymbol(export_name) orelse {
                 failed_exports.appendAssumeCapacity(export_name);
                 continue;
             };
@@ -902,8 +917,15 @@ fn createSyntheticSymbol(wasm: *Wasm, name: []const u8, tag: Symbol.Tag) !Symbol
         .index = undefined,
     });
     try wasm.resolved_symbols.putNoClobber(wasm.base.allocator, loc, {});
-    try wasm.global_symbols.putNoClobber(wasm.base.allocator, name_offset, loc);
+    try wasm.global_symbols.put(wasm.base.allocator, name_offset, loc);
     return loc;
+}
+
+/// Tries to find a global symbol by its name. Returns null when not found,
+/// and its location when it is found.
+fn findGlobalSymbol(wasm: *Wasm, name: []const u8) ?SymbolWithLoc {
+    const offset = wasm.string_table.getOffset(name) orelse return null;
+    return wasm.global_symbols.get(offset);
 }
 
 /// Verifies if we have any undefined, non-function symbols left.
@@ -992,7 +1014,7 @@ fn initializeCallCtorsFunction(wasm: *Wasm) !void {
     // End function body
     try writer.writeByte(std.wasm.opcode(.end));
 
-    const loc = wasm.global_symbols.get(wasm.string_table.getOffset("__wasm_call_ctors").?).?;
+    const loc = wasm.findGlobalSymbol("__wasm_call_ctors").?;
     // Update the symbol
     const symbol = loc.getSymbol(wasm);
     // create type (() -> nil)
@@ -1026,9 +1048,8 @@ fn initializeCallCtorsFunction(wasm: *Wasm) !void {
 
 fn mergeImports(wasm: *Wasm) !void {
     if (wasm.options.import_table and wasm.elements.functionCount() > 0) {
-        const table_offset = wasm.string_table.getOffset("__indirect_function_table").?;
-        const sym_with_loc = wasm.global_symbols.get(table_offset).?;
-        const symbol = sym_with_loc.getSymbol(wasm);
+        const loc = wasm.findGlobalSymbol("__indirect_function_table").?;
+        const symbol = loc.getSymbol(wasm);
         symbol.index = wasm.imports.tableCount();
         try wasm.imports.imported_tables.putNoClobber(wasm.base.allocator, .{
             .module_name = "env",
@@ -1037,7 +1058,7 @@ fn mergeImports(wasm: *Wasm) !void {
             .limits = .{ .min = wasm.elements.functionCount(), .max = null },
             .reftype = .funcref,
         } });
-        try wasm.imports.imported_symbols.append(wasm.base.allocator, sym_with_loc);
+        try wasm.imports.imported_symbols.append(wasm.base.allocator, loc);
     }
 
     for (wasm.resolved_symbols.keys()) |sym_with_loc| {
@@ -1061,6 +1082,8 @@ fn setupMemory(wasm: *Wasm) !void {
     const page_size = std.wasm.page_size;
     const stack_size = wasm.options.stack_size orelse page_size;
     const stack_alignment = 16; // wasm's stack alignment as specified by tool-convention
+    const heap_alignment = 16; // wasm's heap alignment as specified by tool-convention
+
     // Always place the stack at the start by default
     // unless the user specified the global-base flag
     var place_stack_first = true;
@@ -1089,6 +1112,11 @@ fn setupMemory(wasm: *Wasm) !void {
         memory_ptr = std.mem.alignForwardGeneric(u64, memory_ptr, stack_alignment);
         memory_ptr += stack_size;
         wasm.globals.items.items[0].init.i32_const = @bitCast(i32, @intCast(u32, memory_ptr));
+    }
+
+    if (wasm.findGlobalSymbol("__heap_base")) |loc| {
+        const atom = wasm.symbol_atom.get(loc).?;
+        atom.offset = @intCast(u32, mem.alignForwardGeneric(u64, memory_ptr, heap_alignment));
     }
 
     // Setup the max amount of pages
@@ -1292,29 +1320,24 @@ fn allocateAtoms(wasm: *Wasm) !void {
                     }
                 }
             }
-            // offset = std.mem.alignForwardGeneric(u32, offset, atom.alignment);
+            offset = std.mem.alignForwardGeneric(u32, offset, atom.alignment);
             atom.offset = offset;
             offset += atom.size;
             atom = atom.next orelse break;
         }
-        // segment.size = std.mem.alignForwardGeneric(u32, offset, segment.alignment);
-        segment.size = offset;
+        segment.size = std.mem.alignForwardGeneric(u32, offset, segment.alignment);
     }
 }
 
 fn setupStart(wasm: *Wasm) !void {
     if (wasm.options.no_entry) return;
     const entry_name = wasm.options.entry_name orelse "_start";
-    const entry_name_offset = wasm.string_table.getOffset(entry_name) orelse {
+    const entry_loc = wasm.findGlobalSymbol(entry_name) orelse {
         log.err("Entry symbol '{s}' does not exist, use '--no-entry' to suppress", .{entry_name});
         return error.MissingSymbol;
     };
 
-    const symbol_with_loc: SymbolWithLoc = wasm.global_symbols.get(entry_name_offset) orelse {
-        log.err("Entry symbol '{s}' is not a global symbol", .{entry_name});
-        return error.MissingSymbol;
-    };
-    const symbol = symbol_with_loc.getSymbol(wasm);
+    const symbol = entry_loc.getSymbol(wasm);
     if (symbol.tag != .function) {
         log.err("Entry symbol '{s}' is not a function", .{entry_name});
         return error.InvalidEntryKind;

--- a/src/Wasm/Atom.zig
+++ b/src/Wasm/Atom.zig
@@ -95,8 +95,9 @@ pub fn symbolLoc(atom: *const Atom) Wasm.SymbolWithLoc {
 pub fn getVA(atom: *const Atom, wasm_bin: *const Wasm, symbol: *const Symbol) u32 {
     if (symbol.tag == .function) return atom.offset;
     std.debug.assert(symbol.tag == .data);
+    const file_index = atom.file orelse return atom.offset; // offset contains VA for synthetic atoms
     const merge_segment = wasm_bin.options.merge_data_segments;
-    const segment_info = wasm_bin.objects.items[atom.file.?].segment_info;
+    const segment_info = wasm_bin.objects.items[file_index].segment_info;
     const segment_name = segment_info[symbol.index].outputName(merge_segment);
     const segment_index = wasm_bin.data_segments.get(segment_name).?;
     const segment = wasm_bin.segments.items[segment_index];

--- a/src/Wasm/Atom.zig
+++ b/src/Wasm/Atom.zig
@@ -41,20 +41,20 @@ pub const empty: Atom = .{
     .offset = 0,
     .prev = null,
     .size = 0,
-    .sym_index = 0,
+    .sym_index = undefined,
 };
 
 /// Creates a new Atom with default fields
 pub fn create(gpa: Allocator) !*Atom {
     const atom = try gpa.create(Atom);
     atom.* = .{
+        .sym_index = undefined,
         .alignment = 0,
         .file = null,
         .next = null,
         .offset = 0,
         .prev = null,
         .size = 0,
-        .sym_index = 0,
     };
     return atom;
 }
@@ -107,22 +107,9 @@ pub fn getVA(atom: *const Atom, wasm_bin: *const Wasm, symbol: *const Symbol) u3
 /// at the calculated offset.
 pub fn resolveRelocs(atom: *Atom, wasm_bin: *const Wasm) void {
     if (atom.relocs.items.len == 0) return;
-    const sym_name = atom.symbolLoc().getName(wasm_bin);
-
-    log.debug("Resolving relocs in atom '{s}' count({d})", .{
-        sym_name,
-        atom.relocs.items.len,
-    });
 
     for (atom.relocs.items) |reloc| {
         const value = atom.relocationValue(reloc, wasm_bin);
-        log.debug("Relocating '{s}' referenced in '{s}' offset=0x{x:0>8} value={d}", .{
-            (Wasm.SymbolWithLoc{ .file = atom.file, .sym_index = reloc.index }).getName(wasm_bin),
-            sym_name,
-            reloc.offset,
-            value,
-        });
-
         switch (reloc.relocation_type) {
             .R_WASM_TABLE_INDEX_I32,
             .R_WASM_FUNCTION_OFFSET_I32,

--- a/src/Wasm/Options.zig
+++ b/src/Wasm/Options.zig
@@ -18,6 +18,7 @@ const usage =
     \\-o [path]                          Output path of the binary
     \\--entry <entry>                    Name of entry point symbol
     \\--global-base=<value>              Value from where the global data will start
+    \\--import-symbols                   Allows references to undefined symbols
     \\--import-memory                    Import memory from the host environment
     \\--import-table                     Import function table from the host environment
     \\--export-table                     Export function table to the host environment
@@ -42,6 +43,10 @@ positionals: []const []const u8,
 entry_name: ?[]const u8 = null,
 /// Points to where the global data will start
 global_base: ?u32 = null,
+/// Allow undefined symbols to be imported into the linker.
+/// By default the linker will emit an error instead when one or multiple
+/// undefined references are found.
+import_symbols: bool = false,
 /// Tells the linker we will import memory from the host environment
 import_memory: bool = false,
 /// Tells the linker we will import the function table from the host environment
@@ -85,6 +90,7 @@ pub fn parseArgs(arena: Allocator, context: Zld.MainCtx) !Options {
     var positionals = std.ArrayList([]const u8).init(arena);
     var entry_name: ?[]const u8 = null;
     var global_base: ?u32 = null;
+    var import_symbols: bool = false;
     var import_memory: bool = false;
     var import_table: bool = false;
     var export_table: bool = false;
@@ -119,6 +125,8 @@ pub fn parseArgs(arena: Allocator, context: Zld.MainCtx) !Options {
                 "Could not parse value '{s}' into integer",
                 .{arg[index + 1 ..]},
             );
+        } else if (mem.eql(u8, arg, "--import-symbols")) {
+            import_symbols = true;
         } else if (mem.eql(u8, arg, "--import-memory")) {
             import_memory = true;
         } else if (mem.eql(u8, arg, "--import-table")) {
@@ -190,6 +198,7 @@ pub fn parseArgs(arena: Allocator, context: Zld.MainCtx) !Options {
         .positionals = positionals.items,
         .entry_name = entry_name,
         .global_base = global_base,
+        .import_symbols = import_symbols,
         .import_memory = import_memory,
         .import_table = import_table,
         .export_table = export_table,

--- a/src/Wasm/emit_wasm.zig
+++ b/src/Wasm/emit_wasm.zig
@@ -153,10 +153,6 @@ pub fn emit(wasm: *Wasm) !void {
 
             var current_offset: u32 = 0;
             while (true) {
-                if (!wasm.resolved_symbols.contains(atom.symbolLoc())) {
-                    atom = atom.next orelse break;
-                    continue;
-                }
                 atom.resolveRelocs(wasm);
                 // TODO: Verify if this is faster than allocating segment's size
                 // Setting all zeroes, memcopy all segments and then writing.


### PR DESCRIPTION
This implements the `__heap_base` symbol which is referenced by libc's allocator/brk and requires it to fulfill its allocations. In addition, this implements some fixes in `setupInitFuncs` and also implements the `--import-symbols` flag. This means zld can now successfully link with WASI-libc!