### PR TITLE
elf: auto-infer target CPU architecture

### DIFF
--- a/src/Elf/Archive.zig
+++ b/src/Elf/Archive.zig
@@ -171,7 +171,7 @@ fn getExtName(self: Archive, off: u32) []const u8 {
     return mem.sliceTo(@ptrCast([*:'\n']const u8, self.extnames_strtab.items.ptr + off), 0);
 }
 
-pub fn parseObject(self: Archive, allocator: Allocator, cpu_arch: std.Target.Cpu.Arch, offset: u32) !Object {
+pub fn parseObject(self: Archive, allocator: Allocator, offset: u32) !Object {
     const reader = self.file.reader();
     try reader.context.seekTo(offset);
 
@@ -205,7 +205,7 @@ pub fn parseObject(self: Archive, allocator: Allocator, cpu_arch: std.Target.Cpu
         .data = data,
     };
 
-    try object.parse(allocator, cpu_arch);
+    try object.parse(allocator);
 
     return object;
 }

--- a/src/Elf/Object.zig
+++ b/src/Elf/Object.zig
@@ -39,7 +39,7 @@ pub fn deinit(self: *Object, allocator: Allocator) void {
     allocator.free(self.data);
 }
 
-pub fn parse(self: *Object, allocator: Allocator, cpu_arch: std.Target.Cpu.Arch) !void {
+pub fn parse(self: *Object, allocator: Allocator) !void {
     var stream = std.io.fixedBufferStream(self.data);
     const reader = stream.reader();
 
@@ -62,18 +62,11 @@ pub fn parse(self: *Object, allocator: Allocator, cpu_arch: std.Target.Cpu.Arch)
         return error.TODOElf32bitSupport;
     }
     if (self.header.e_type != elf.ET.REL) {
-        log.debug("Invalid file type {any}, expected ET.REL", .{self.header.e_type});
+        log.err("Invalid file type {any}, expected ET.REL", .{self.header.e_type});
         return error.NotObject;
     }
-    if (self.header.e_machine != cpu_arch.toElfMachine()) {
-        log.debug("Invalid architecture {any}, expected {any}", .{
-            self.header.e_machine,
-            cpu_arch.toElfMachine(),
-        });
-        return error.InvalidCpuArch;
-    }
     if (self.header.e_version != 1) {
-        log.debug("Invalid ELF version {d}, expected 1", .{self.header.e_version});
+        log.err("Invalid ELF version {d}, expected 1", .{self.header.e_version});
         return error.NotObject;
     }
 

--- a/src/Elf/Options.zig
+++ b/src/Elf/Options.zig
@@ -7,7 +7,6 @@ const mem = std.mem;
 const process = std.process;
 
 const Allocator = mem.Allocator;
-const CrossTarget = std.zig.CrossTarget;
 const Elf = @import("../Elf.zig");
 const Zld = @import("../Zld.zig");
 
@@ -32,7 +31,6 @@ const usage =
 
 emit: Zld.Emit,
 output_mode: Zld.OutputMode,
-target: CrossTarget,
 positionals: []const Zld.LinkObject,
 libs: std.StringArrayHashMap(Zld.SystemLib),
 lib_dirs: []const []const u8,
@@ -130,7 +128,6 @@ pub fn parseArgs(arena: Allocator, ctx: Zld.MainCtx) !Options {
             .directory = std.fs.cwd(),
             .sub_path = out_path orelse "a.out",
         },
-        .target = CrossTarget.fromTarget(builtin.target),
         .output_mode = if (shared) .lib else .exe,
         .positionals = positionals.items,
         .libs = libs,

--- a/src/test.zig
+++ b/src/test.zig
@@ -303,7 +303,6 @@ pub const TestContext = struct {
                         .directory = std.fs.cwd(),
                         .sub_path = output_path,
                     },
-                    .target = case.target,
                     .output_mode = .exe,
                     .positionals = objects.items,
                     .libs = libs,


### PR DESCRIPTION
This enables `ld.zld` to be used as a cross-linker for ELF files.