### PR TITLE
wasm: Finish TLS & shared-memory implementation

### DIFF
--- a/src/Wasm.zig
+++ b/src/Wasm.zig
@@ -63,8 +63,8 @@ imports: sections.Imports = .{},
 functions: sections.Functions = .{},
 /// Output table section
 tables: sections.Tables = .{},
-/// Output memory section, this will only be used when `options.import_memory`
-/// is set to false. The limits will be set, based on the total data section size
+/// Output memory section, this will only be used when `options.export_memory`
+/// is set to `true`. The limits will be set, based on the total data section size
 /// and other configuration options.
 memories: std.wasm.Memory = .{ .limits = .{
     .flags = 0,
@@ -858,9 +858,7 @@ fn mergeTypes(wasm: *Wasm) !void {
 fn setupExports(wasm: *Wasm) !void {
     log.debug("Building exports from symbols", .{});
 
-    // When importing memory option is false,
-    // we export the memory.
-    if (!wasm.options.import_memory) {
+    if (wasm.options.export_memory) {
         try wasm.exports.append(wasm.base.allocator, .{ .name = "memory", .kind = .memory, .index = 0 });
     }
 

--- a/src/Wasm.zig
+++ b/src/Wasm.zig
@@ -1199,8 +1199,8 @@ fn setupInitMemoryFunction(wasm: *Wasm) !void {
         try leb.writeULEB128(writer, flag_address);
         try writer.writeByte(std.wasm.opcode(.i32_const));
         try leb.writeULEB128(writer, @as(u32, 1)); // expected flag value
-        try writer.writeByte(std.wasm.opcode(.i32_const));
-        try leb.writeILEB128(writer, @as(i32, -1)); // timeout
+        try writer.writeByte(std.wasm.opcode(.i64_const));
+        try leb.writeILEB128(writer, @as(i64, -1)); // timeout
         try writer.writeByte(std.wasm.opcode(.atomics_prefix));
         try leb.writeULEB128(writer, std.wasm.atomicsOpcode(.memory_atomic_wait32));
         try leb.writeULEB128(writer, @as(u32, 2)); // alignment
@@ -1380,7 +1380,7 @@ fn initializeTLSFunction(wasm: *Wasm) !void {
         try leb.writeULEB128(writer, param_local);
 
         const tls_base_loc = wasm.findGlobalSymbol("__tls_base").?;
-        try writer.writeByte(std.wasm.opcode(.global_get));
+        try writer.writeByte(std.wasm.opcode(.global_set));
         try leb.writeULEB128(writer, tls_base_loc.getSymbol(wasm).index);
 
         // load stack values for the bulk-memory operation
@@ -1401,7 +1401,7 @@ fn initializeTLSFunction(wasm: *Wasm) !void {
         // segment immediate
         try leb.writeULEB128(writer, @as(u32, @intCast(data_index)));
         // memory index immediate (always 0)
-        try writer.writeByte(@as(u32, 0));
+        try writer.writeByte(0);
     }
 
     // If we have to perform any TLS relocations, call the corresponding function

--- a/src/Wasm/Atom.zig
+++ b/src/Wasm/Atom.zig
@@ -159,24 +159,25 @@ fn relocationValue(atom: *Atom, relocation: types.Relocation, wasm_bin: *const W
                 return 0;
             }
             const va = @as(i32, @intCast(symbol.virtual_address));
-            return @as(u32, @intCast(va + relocation.addend));
+            return @intCast(va + relocation.addend);
         },
         .R_WASM_EVENT_INDEX_LEB => return symbol.index,
         .R_WASM_SECTION_OFFSET_I32 => {
             const target_atom = wasm_bin.symbol_atom.get(target_loc).?;
-            const rel_value = @as(i32, @intCast(target_atom.offset)) + relocation.addend;
-            return @as(u32, @intCast(rel_value));
+            const rel_value: i32 = @intCast(target_atom.offset);
+            return @intCast(rel_value + relocation.addend);
         },
         .R_WASM_FUNCTION_OFFSET_I32 => {
             const target_atom = wasm_bin.symbol_atom.get(target_loc).?;
             const offset: u32 = 11 + Wasm.getULEB128Size(target_atom.size); // Header (11 bytes fixed-size) + body size (leb-encoded)
-            const rel_value = @as(i32, @intCast(target_atom.offset + offset)) + relocation.addend;
-            return @as(u32, @intCast(rel_value));
+            const rel_value: i32 = @intCast(target_atom.offset + offset);
+            return @intCast(rel_value + relocation.addend);
         },
         .R_WASM_MEMORY_ADDR_TLS_SLEB,
         .R_WASM_MEMORY_ADDR_TLS_SLEB64,
         => {
-            @panic("TODO: Implement TLS relocations");
+            const va: i32 = @intCast(symbol.virtual_address);
+            return @intCast(va + relocation.addend);
         },
     }
 }

--- a/src/Wasm/Options.zig
+++ b/src/Wasm/Options.zig
@@ -20,6 +20,7 @@ const usage =
     \\--global-base=<value>              Value from where the global data will start
     \\--import-symbols                   Allows references to undefined symbols
     \\--import-memory                    Import memory from the host environment
+    \\--export-memory                    Import memory from the host environment
     \\--import-table                     Import function table from the host environment
     \\--export-table                     Export function table to the host environment
     \\--initial-memory=<value>           Initial size of the linear memory
@@ -50,6 +51,8 @@ global_base: ?u32 = null,
 import_symbols: bool = false,
 /// Tells the linker we will import memory from the host environment
 import_memory: bool = false,
+/// Tells the linker we will export memory from the host environment
+export_memory: bool = false,
 /// Tells the linker we will import the function table from the host environment
 import_table: bool = false,
 /// Tells the linker we will export the function table to the host environment
@@ -95,6 +98,7 @@ pub fn parse(arena: Allocator, args: []const []const u8, ctx: anytype) !Options 
     var global_base: ?u32 = null;
     var import_symbols: bool = false;
     var import_memory: bool = false;
+    var export_memory: ?bool = null;
     var import_table: bool = false;
     var export_table: bool = false;
     var initial_memory: ?u32 = null;
@@ -126,6 +130,8 @@ pub fn parse(arena: Allocator, args: []const []const u8, ctx: anytype) !Options 
             import_symbols = true;
         } else if (mem.eql(u8, arg, "--import-memory")) {
             import_memory = true;
+        } else if (mem.eql(u8, arg, "--export-memory")) {
+            export_memory = true;
         } else if (mem.eql(u8, arg, "--import-table")) {
             import_table = true;
         } else if (mem.eql(u8, arg, "--export-table")) {
@@ -183,6 +189,7 @@ pub fn parse(arena: Allocator, args: []const []const u8, ctx: anytype) !Options 
         .global_base = global_base,
         .import_symbols = import_symbols,
         .import_memory = import_memory,
+        .export_memory = export_memory orelse !import_memory,
         .import_table = import_table,
         .export_table = export_table,
         .initial_memory = initial_memory,

--- a/src/Wasm/types.zig
+++ b/src/Wasm/types.zig
@@ -50,6 +50,8 @@ pub const Relocation = struct {
                 .R_WASM_MEMORY_ADDR_LEB64,
                 .R_WASM_MEMORY_ADDR_SLEB64,
                 .R_WASM_MEMORY_ADDR_I64,
+                .R_WASM_MEMORY_ADDR_TLS_SLEB,
+                .R_WASM_MEMORY_ADDR_TLS_SLEB64,
                 .R_WASM_FUNCTION_OFFSET_I32,
                 .R_WASM_SECTION_OFFSET_I32,
                 => true,


### PR DESCRIPTION
This implements TLS relocations and fixes various issues in the shared-memory implementation. With these additions, we can now correctly link the threading example from the Zig main repo. The last remaining step for full static-linking support is garbage collection.
