### PR TITLE
wasm - implement garbage collection

### DIFF
--- a/src/Wasm.zig
+++ b/src/Wasm.zig
@@ -1814,19 +1814,17 @@ fn allocateAtoms(wasm: *Wasm) !void {
         var offset: u32 = 0;
         while (true) {
             const symbol_loc = atom.symbolLoc();
-            if (wasm.code_section_index) |index| {
-                if (entry.key_ptr.* == index) {
-                    const sym = symbol_loc.getSymbol(wasm);
-                    if (sym.isDead()) {
-                        var next = atom.next;
-                        var prev = atom.prev.?;
-                        prev.next = next;
-
-                        atom = next orelse break;
-                        atom.prev = prev;
-                        continue;
-                    }
+            const sym = symbol_loc.getSymbol(wasm);
+            if (sym.isDead()) {
+                var next = atom.next;
+                var prev = atom.prev;
+                if (prev) |has_prev| {
+                    has_prev.next = next;
                 }
+
+                atom = next orelse break;
+                atom.prev = prev;
+                continue;
             }
             offset = std.mem.alignForward(u32, offset, atom.alignment);
             atom.offset = offset;

--- a/src/Wasm.zig
+++ b/src/Wasm.zig
@@ -1816,8 +1816,14 @@ fn allocateAtoms(wasm: *Wasm) !void {
             const symbol_loc = atom.symbolLoc();
             if (wasm.code_section_index) |index| {
                 if (entry.key_ptr.* == index) {
-                    if (!wasm.resolved_symbols.contains(symbol_loc)) {
-                        atom = atom.next orelse break;
+                    const sym = symbol_loc.getSymbol(wasm);
+                    if (sym.isDead()) {
+                        var next = atom.next;
+                        var prev = atom.prev.?;
+                        prev.next = next;
+
+                        atom = next orelse break;
+                        atom.prev = prev;
                         continue;
                     }
                 }

--- a/src/Wasm/Atom.zig
+++ b/src/Wasm/Atom.zig
@@ -132,6 +132,7 @@ pub fn resolveRelocs(atom: *Atom, wasm_bin: *const Wasm) void {
 fn relocationValue(atom: *Atom, relocation: types.Relocation, wasm_bin: *const Wasm) u64 {
     const target_loc = (Wasm.SymbolWithLoc{ .file = atom.file, .sym_index = relocation.index }).finalLoc(wasm_bin);
     const symbol = target_loc.getSymbol(wasm_bin);
+    std.debug.assert(symbol.isAlive());
     switch (relocation.relocation_type) {
         .R_WASM_FUNCTION_INDEX_LEB => return symbol.index,
         .R_WASM_TABLE_NUMBER_LEB => return symbol.index,

--- a/src/Wasm/Atom.zig
+++ b/src/Wasm/Atom.zig
@@ -19,7 +19,7 @@ size: u32,
 /// List of relocations belonging to this atom
 relocs: std.ArrayListUnmanaged(types.Relocation) = .{},
 /// Contains the binary data of an atom, which can be non-relocated
-code: std.ArrayListUnmanaged(u8) = .{},
+data: [*]u8,
 /// For code this is 1, for data this is set to the highest value of all segments
 alignment: u32,
 /// Offset into the section where the atom lives, this already accounts
@@ -55,6 +55,7 @@ pub fn create(gpa: Allocator) !*Atom {
         .offset = 0,
         .prev = null,
         .size = 0,
+        .data = undefined,
     };
     return atom;
 }
@@ -63,7 +64,6 @@ pub fn create(gpa: Allocator) !*Atom {
 /// Also destroys itatom, making any usage of this atom illegal.
 pub fn deinit(atom: *Atom, gpa: Allocator) void {
     atom.relocs.deinit(gpa);
-    atom.code.deinit(gpa);
     gpa.destroy(atom);
 }
 
@@ -103,10 +103,10 @@ pub fn resolveRelocs(atom: *Atom, wasm_bin: *const Wasm) void {
             .R_WASM_GLOBAL_INDEX_I32,
             .R_WASM_MEMORY_ADDR_I32,
             .R_WASM_SECTION_OFFSET_I32,
-            => std.mem.writeIntLittle(u32, atom.code.items[reloc.offset..][0..4], @as(u32, @truncate(value))),
+            => std.mem.writeIntLittle(u32, atom.data[reloc.offset..][0..4], @as(u32, @truncate(value))),
             .R_WASM_TABLE_INDEX_I64,
             .R_WASM_MEMORY_ADDR_I64,
-            => std.mem.writeIntLittle(u64, atom.code.items[reloc.offset..][0..8], value),
+            => std.mem.writeIntLittle(u64, atom.data[reloc.offset..][0..8], value),
             .R_WASM_GLOBAL_INDEX_LEB,
             .R_WASM_EVENT_INDEX_LEB,
             .R_WASM_FUNCTION_INDEX_LEB,
@@ -116,12 +116,12 @@ pub fn resolveRelocs(atom: *Atom, wasm_bin: *const Wasm) void {
             .R_WASM_TABLE_NUMBER_LEB,
             .R_WASM_TYPE_INDEX_LEB,
             .R_WASM_MEMORY_ADDR_TLS_SLEB,
-            => leb.writeUnsignedFixed(5, atom.code.items[reloc.offset..][0..5], @as(u32, @truncate(value))),
+            => leb.writeUnsignedFixed(5, atom.data[reloc.offset..][0..5], @as(u32, @truncate(value))),
             .R_WASM_MEMORY_ADDR_LEB64,
             .R_WASM_MEMORY_ADDR_SLEB64,
             .R_WASM_TABLE_INDEX_SLEB64,
             .R_WASM_MEMORY_ADDR_TLS_SLEB64,
-            => leb.writeUnsignedFixed(10, atom.code.items[reloc.offset..][0..10], value),
+            => leb.writeUnsignedFixed(10, atom.data[reloc.offset..][0..10], value),
         }
     }
 }

--- a/src/Wasm/Object.zig
+++ b/src/Wasm/Object.zig
@@ -8,6 +8,7 @@ const types = @import("types.zig");
 const std = @import("std");
 const Wasm = @import("../Wasm.zig");
 const Symbol = @import("Symbol.zig");
+const trace = @import("../tracy.zig").trace;
 
 const Allocator = std.mem.Allocator;
 const leb = std.leb;
@@ -913,6 +914,8 @@ fn assertEnd(reader: anytype) !void {
 
 /// Parses an object file into atoms, for code and data sections
 pub fn parseIntoAtoms(object: *Object, object_index: u16, wasm_bin: *Wasm) !void {
+    const tracy = trace(@src());
+    defer tracy.end();
     const Key = struct {
         kind: Symbol.Tag,
         index: u32,

--- a/src/Wasm/Object.zig
+++ b/src/Wasm/Object.zig
@@ -957,7 +957,7 @@ pub fn parseIntoAtoms(object: *Object, object_index: u16, wasm_bin: *Wasm) !void
         atom.file = object_index;
         atom.size = relocatable_data.size;
         atom.alignment = relocatable_data.getAlignment(object);
-        try atom.code.appendSlice(wasm_bin.base.allocator, relocatable_data.data[0..relocatable_data.size]);
+        atom.data = relocatable_data.data;
 
         const relocations: []types.Relocation = object.relocations.get(relocatable_data.section_index) orelse &.{};
         for (relocations) |relocation| {

--- a/src/Wasm/Object.zig
+++ b/src/Wasm/Object.zig
@@ -924,7 +924,7 @@ pub fn parseIntoAtoms(object: *Object, object_index: u16, wasm_bin: *Wasm) !void
 
     for (object.symtable, 0..) |symbol, symbol_index| {
         switch (symbol.tag) {
-            .function, .data, .section => if (!symbol.isUndefined()) {
+            .function, .data, .section => if (symbol.isDefined()) {
                 const gop = try symbol_for_segment.getOrPut(.{ .kind = symbol.tag, .index = symbol.index });
                 const sym_idx = @as(u32, @intCast(symbol_index));
                 if (!gop.found_existing) {

--- a/src/Wasm/Object.zig
+++ b/src/Wasm/Object.zig
@@ -1021,7 +1021,7 @@ pub fn parseIntoAtoms(object: *Object, object_index: u16, wasm_bin: *Wasm) !void
             } else if (relocatable_data.type == .debug) {
                 atom.sym_index = @intCast(object.symtable.len + synthetic_symbols.items.len);
                 var sym: Symbol = .{
-                    .tag = .data,
+                    .tag = .section,
                     .index = relocatable_data.section_index,
                     .name = relocatable_data.index,
                     .flags = 0x2, // local

--- a/src/Wasm/Symbol.zig
+++ b/src/Wasm/Symbol.zig
@@ -8,8 +8,8 @@ const Symbol = @This();
 const std = @import("std");
 const types = @import("types.zig");
 
-/// Bitfield containings flags for a symbol
-/// Can contain any of the flags defined in `Flag`
+/// Bitfield containings flags for a symbol.
+/// Can contain any of the flags defined in `Flag`.
 flags: u32,
 /// Symbol name, when the symbol is undefined the name will be taken from the import.
 /// Note: This is an index into the string table.
@@ -73,7 +73,20 @@ pub const Flag = enum(u32) {
     WASM_SYM_NO_STRIP = 0x80,
     /// Indicates a symbol is TLS
     WASM_SYM_TLS = 0x100,
+
+    /// Zld specific flag. Uses the most significant bit of the flag to annotate whether a symbol is
+    /// alive or not. Dead symbols are allowed to be garbage collected.
+    alive = 0x80000000,
 };
+
+/// Marks a symbol as 'alive', ensuring the garbage collector will not collect the trash.
+pub fn mark(symbol: *Symbol) void {
+    symbol.flags |= @intFromEnum(Flag.alive);
+}
+
+pub fn isAlive(symbol: Symbol) bool {
+    return symbol.flags & @intFromEnum(Flag.alive) != 0;
+}
 
 /// Verifies if the given symbol should be imported from the
 /// host environment or not

--- a/src/Wasm/Symbol.zig
+++ b/src/Wasm/Symbol.zig
@@ -84,8 +84,12 @@ pub fn mark(symbol: *Symbol) void {
     symbol.flags |= @intFromEnum(Flag.alive);
 }
 
-pub fn isAlive(symbol: Symbol) bool {
+pub inline fn isAlive(symbol: Symbol) bool {
     return symbol.flags & @intFromEnum(Flag.alive) != 0;
+}
+
+pub inline fn isDead(symbol: Symbol) bool {
+    return symbol.flags & @intFromEnum(Flag.alive) == 0;
 }
 
 /// Verifies if the given symbol should be imported from the

--- a/src/Wasm/emit_wasm.zig
+++ b/src/Wasm/emit_wasm.zig
@@ -119,10 +119,9 @@ pub fn emit(wasm: *Wasm) !void {
 
         while (true) {
             const loc = atom.symbolLoc();
-            if (loc.getSymbol(wasm).isAlive() and wasm.resolved_symbols.contains(loc)) {
-                atom.resolveRelocs(wasm);
-                sorted_atoms.appendAssumeCapacity(atom);
-            }
+            std.debug.assert(loc.getSymbol(wasm).isAlive());
+            atom.resolveRelocs(wasm);
+            sorted_atoms.appendAssumeCapacity(atom);
             atom = atom.next orelse break;
         }
 


### PR DESCRIPTION
Implements garbage collection to remove unreferenced symbols and their sections. Also fixes a TLS bug and improves the performance by 66% (3sec to 1sec in debug) due to a logical bug in `parseIntoAtoms`. (This is while linking Zig's behavior test suite for Wasm with compiler_rt and libc).
