### PR TITLE
macho: tie FDEs and unwind records to all symbol aliases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
         version: master
     - run: zig version
     - run: zig fmt --check src 
-    - run: zig build test -Dhas-static
+    - run: zig build test -Dhas-static -Dhas-zig
 
   gcc_musl:
     name: Test gcc with musl

--- a/build.zig
+++ b/build.zig
@@ -71,6 +71,7 @@ pub fn build(b: *std.Build.Builder) void {
 
     const system_compiler = b.option(tests.SystemCompiler, "system-compiler", "System compiler we are utilizing for tests: gcc, clang");
     const has_static = b.option(bool, "has-static", "Whether the system compiler supports '-static' flag") orelse false;
+    const has_zig = b.option(bool, "has-zig", "Whether the Zig compiler is in path") orelse false;
     const is_musl = b.option(bool, "musl", "Whether the tests are linked against musl libc") orelse false;
 
     const unit_tests = b.addTest(.{
@@ -91,6 +92,7 @@ pub fn build(b: *std.Build.Builder) void {
     test_step.dependOn(tests.addTests(b, exe, .{
         .system_compiler = system_compiler,
         .has_static = has_static,
+        .has_zig = has_zig,
         .is_musl = is_musl,
     }));
 }

--- a/src/MachO/Object.zig
+++ b/src/MachO/Object.zig
@@ -722,7 +722,7 @@ fn parseEhFrameSection(self: *Object, macho_file: *MachO, object_id: u32) !void 
     }
 
     try self.eh_frame_relocs_lookup.ensureTotalCapacity(gpa, record_count);
-    try self.eh_frame_records_lookup.ensureTotalCapacity(gpa, record_count);
+    try self.eh_frame_records_lookup.ensureUnusedCapacity(gpa, record_count);
 
     it.reset();
 
@@ -772,11 +772,28 @@ fn parseEhFrameSection(self: *Object, macho_file: *MachO, object_id: u32) !void 
                     else => unreachable,
                 }
             };
-            log.debug("FDE at offset {x} tracks {s}", .{ offset, macho_file.getSymbolName(target) });
             if (target.getFile() != object_id) {
+                log.debug("FDE at offset {x} marked DEAD", .{offset});
                 self.eh_frame_relocs_lookup.getPtr(offset).?.dead = true;
             } else {
-                self.eh_frame_records_lookup.putAssumeCapacityNoClobber(target, offset);
+                // You would think that we are done but turns out that the compilers may use
+                // whichever symbol alias they want for a target symbol. This in particular
+                // very problematic when using Zig's @export feature to re-export symbols under
+                // additional names. For that reason, we need to ensure we record aliases here
+                // too so that we can tie them with their matching unwind records and vice versa.
+                const aliases = self.getSymbolAliases(target.sym_index);
+                var i: u32 = 0;
+                while (i < aliases.len) : (i += 1) {
+                    const actual_target = SymbolWithLoc{
+                        .sym_index = i + aliases.start,
+                        .file = target.file,
+                    };
+                    log.debug("FDE at offset {x} tracks {s}", .{
+                        offset,
+                        macho_file.getSymbolName(actual_target),
+                    });
+                    try self.eh_frame_records_lookup.putNoClobber(gpa, actual_target, offset);
+                }
             }
         }
     }
@@ -807,7 +824,7 @@ fn parseUnwindInfo(self: *Object, macho_file: *MachO, object_id: u32) !void {
 
     const unwind_records = self.getUnwindRecords();
 
-    try self.unwind_records_lookup.ensureTotalCapacity(gpa, @as(u32, @intCast(unwind_records.len)));
+    try self.unwind_records_lookup.ensureUnusedCapacity(gpa, @as(u32, @intCast(unwind_records.len)));
 
     const needs_eh_frame = for (unwind_records) |record| {
         if (UnwindInfo.UnwindEncoding.isDwarf(record.compactUnwindEncoding, cpu_arch)) break true;
@@ -840,11 +857,28 @@ fn parseUnwindInfo(self: *Object, macho_file: *MachO, object_id: u32) !void {
             .code = mem.asBytes(&record),
             .base_offset = @as(i32, @intCast(offset)),
         });
-        log.debug("unwind record {d} tracks {s}", .{ record_id, macho_file.getSymbolName(target) });
         if (target.getFile() != object_id) {
+            log.debug("unwind record {d} marked DEAD", .{record_id});
             self.unwind_relocs_lookup[record_id].dead = true;
         } else {
-            self.unwind_records_lookup.putAssumeCapacityNoClobber(target, @as(u32, @intCast(record_id)));
+            // You would think that we are done but turns out that the compilers may use
+            // whichever symbol alias they want for a target symbol. This in particular
+            // very problematic when using Zig's @export feature to re-export symbols under
+            // additional names. For that reason, we need to ensure we record aliases here
+            // too so that we can tie them with their matching unwind records and vice versa.
+            const aliases = self.getSymbolAliases(target.sym_index);
+            var i: u32 = 0;
+            while (i < aliases.len) : (i += 1) {
+                const actual_target = SymbolWithLoc{
+                    .sym_index = i + aliases.start,
+                    .file = target.file,
+                };
+                log.debug("unwind record {d} tracks {s}", .{
+                    record_id,
+                    macho_file.getSymbolName(actual_target),
+                });
+                try self.unwind_records_lookup.putNoClobber(gpa, actual_target, @intCast(record_id));
+            }
         }
     }
 }
@@ -992,6 +1026,18 @@ pub fn getSymbolName(self: Object, index: u32) []const u8 {
     return strtab[start..][0 .. len - 1 :0];
 }
 
+fn getSymbolAliases(self: Object, index: u32) Entry {
+    const addr = self.source_address_lookup[index];
+    var start = index;
+    while (start > 0 and
+        self.source_address_lookup[start - 1] == addr) : (start -= 1)
+    {}
+    const end: u32 = for (self.source_address_lookup[start..], start..) |saddr, i| {
+        if (saddr != addr) break @as(u32, @intCast(i));
+    } else @as(u32, @intCast(self.source_address_lookup.len));
+    return .{ .start = start, .len = end - start };
+}
+
 pub fn getSymbolByAddress(self: Object, addr: u64, sect_hint: ?u8) u32 {
     // Find containing atom
     const Predicate = struct {
@@ -1013,11 +1059,8 @@ pub fn getSymbolByAddress(self: Object, addr: u64, sect_hint: ?u8) u32 {
             if (target_sym_index > 0) {
                 // Hone in on the most senior alias of the target symbol.
                 // See SymbolAtIndex.lessThan for more context.
-                var start = target_sym_index - 1;
-                while (start > 0 and
-                    self.source_address_lookup[lookup.start..][start - 1] == addr) : (start -= 1)
-                {}
-                return @as(u32, @intCast(lookup.start + start));
+                const aliases = self.getSymbolAliases(@intCast(lookup.start + target_sym_index - 1));
+                return aliases.start;
             }
         }
         return self.getSectionAliasSymbolIndex(sect_id);


### PR DESCRIPTION
This is in particular very important to the Zig language which allows exporting the same symbol under different names. For instance, it is possible to have a case such that:

```
...
4258 T _foo
4258 T _bar
...
```

In this case we need to keep track of both symbol names when resolving FDEs and unwind records.

Also add ability to shell out to Zig when running tests - we can now build objects using Zig toolchain also!