### PR TITLE
macho: reduce heap allocations

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -12,6 +12,7 @@ pub fn build(b: *std.Build) void {
     const strip = b.option(bool, "strip", "Omit debug information");
     const enable_logging = b.option(bool, "log", "Whether to enable logging") orelse (mode == .Debug);
     const enable_tracy = b.option([]const u8, "tracy", "Enable Tracy integration. Supply path to Tracy source");
+    const tracy_callstack_depth = b.option(usize, "tracy-callstack-depth", "Set Tracy callstack depth") orelse 10;
 
     const yaml = b.dependency("zig-yaml", .{
         .target = target,
@@ -37,6 +38,7 @@ pub fn build(b: *std.Build) void {
     exe.root_module.addOptions("build_options", exe_opts);
     exe_opts.addOption(bool, "enable_logging", enable_logging);
     exe_opts.addOption(bool, "enable_tracy", enable_tracy != null);
+    exe_opts.addOption(usize, "tracy_callstack_depth", tracy_callstack_depth);
 
     if (enable_tracy) |tracy_path| {
         const client_cpp = fs.path.join(

--- a/src/MachO.zig
+++ b/src/MachO.zig
@@ -2137,6 +2137,7 @@ fn writeAtoms(self: *MachO) !void {
             const atom = self.getAtom(atom_index).?;
             assert(atom.flags.alive);
             const off = atom.value - header.addr;
+            try atom.getCode(self, buffer[off..][0..atom.size]);
             atom.resolveRelocs(self, buffer[off..][0..atom.size]) catch |err| switch (err) {
                 error.ResolveFailed => has_resolve_error = true,
                 else => |e| return e,

--- a/src/MachO.zig
+++ b/src/MachO.zig
@@ -691,7 +691,7 @@ fn parseObject(self: *MachO, obj: LinkObject) !bool {
 
     const index = @as(File.Index, @intCast(try self.files.addOne(gpa)));
     self.files.set(index, .{ .object = .{
-        .path = obj.path,
+        .path = try gpa.dupe(u8, obj.path),
         .file = file,
         .index = index,
         .mtime = mtime,

--- a/src/MachO.zig
+++ b/src/MachO.zig
@@ -2885,6 +2885,7 @@ pub fn getOrCreateGlobal(self: *MachO, off: u32) !GetOrCreateGlobalResult {
     if (!gop.found_existing) {
         const index = try self.addSymbol();
         const global = self.getSymbol(index);
+        global.flags.global = true;
         global.name = off;
         gop.value_ptr.* = index;
     }

--- a/src/MachO.zig
+++ b/src/MachO.zig
@@ -1226,10 +1226,6 @@ fn createObjcSections(self: *MachO) !void {
         const internal = self.getInternalObject().?;
         const sym = self.getSymbol(sym_index);
         _ = try internal.addSymbol(sym.getName(self), self);
-        sym.value = 0;
-        sym.atom = 0;
-        sym.nlist_idx = 0;
-        sym.flags = .{ .global = true };
         sym.visibility = .hidden;
         const name = eatPrefix(sym.getName(self), "_objc_msgSend$").?;
         const selrefs_index = try internal.addObjcMsgsendSections(name, self);

--- a/src/MachO.zig
+++ b/src/MachO.zig
@@ -1086,6 +1086,8 @@ fn deadStripDylibs(self: *MachO) void {
         const index = self.dylibs.items[i];
         if (!self.getFile(index).?.dylib.isAlive(self)) {
             _ = self.dylibs.orderedRemove(i);
+            self.files.items(.data)[index].dylib.deinit(self.base.allocator);
+            self.files.set(index, .null);
         } else i += 1;
     }
 }

--- a/src/MachO.zig
+++ b/src/MachO.zig
@@ -1240,18 +1240,17 @@ fn createObjcSections(self: *MachO) !void {
     }
 
     for (objc_msgsend_syms.keys()) |sym_index| {
+        const internal = self.getInternalObject().?;
         const sym = self.getSymbol(sym_index);
+        _ = try internal.addSymbol(sym.getName(self), self);
         sym.value = 0;
         sym.atom = 0;
         sym.nlist_idx = 0;
-        sym.file = self.internal_object_index.?;
-        sym.flags = .{};
+        sym.flags = .{ .global = true };
         sym.visibility = .hidden;
-        const object = self.getInternalObject().?;
         const name = eatPrefix(sym.getName(self), "_objc_msgSend$").?;
-        const selrefs_index = try object.addObjcMsgsendSections(name, self);
+        const selrefs_index = try internal.addObjcMsgsendSections(name, self);
         try sym.addExtra(.{ .objc_selrefs = selrefs_index }, self);
-        try object.symbols.append(gpa, sym_index);
     }
 }
 

--- a/src/MachO/Atom.zig
+++ b/src/MachO/Atom.zig
@@ -66,7 +66,7 @@ pub fn getCode(self: Atom, macho_file: *MachO) ![]const u8 {
     const code = switch (self.getFile(macho_file)) {
         .dylib => unreachable,
         .object => |x| try x.getSectionData(gpa, self.n_sect),
-        .internal => |x| x.getSectionData(self.n_sect),
+        .internal => |x| try gpa.dupe(u8, x.getSectionData(self.n_sect)),
     };
     return code[self.off..][0..self.size];
 }

--- a/src/MachO/Atom.zig
+++ b/src/MachO/Atom.zig
@@ -38,7 +38,7 @@ unwind_records: Loc = .{},
 flags: Flags = .{},
 
 pub fn getName(self: Atom, macho_file: *MachO) [:0]const u8 {
-    return macho_file.string_intern.getAssumeExists(self.name);
+    return self.getFile(macho_file).object.getString(self.name);
 }
 
 pub fn getFile(self: Atom, macho_file: *MachO) File {

--- a/src/MachO/Atom.zig
+++ b/src/MachO/Atom.zig
@@ -69,7 +69,7 @@ pub fn getCode(self: Atom, macho_file: *MachO, buffer: []u8) !void {
             const slice = x.sections.slice();
             const offset = if (x.archive) |ar| ar.offset else 0;
             const sect = slice.items(.header)[self.n_sect];
-            try x.getData(sect.offset + offset + self.off, buffer);
+            try x.preadAll(buffer, sect.offset + offset + self.off);
         },
         .internal => |x| {
             const code = x.getSectionData(self.n_sect);
@@ -86,7 +86,7 @@ pub fn getCodeAlloc(self: Atom, macho_file: *MachO) ![]const u8 {
             const slice = x.sections.slice();
             const offset = if (x.archive) |ar| ar.offset else 0;
             const sect = slice.items(.header)[self.n_sect];
-            return x.getDataAlloc(gpa, sect.offset + offset + self.off, self.size);
+            return x.preadAllAlloc(gpa, sect.offset + offset + self.off, self.size);
         },
         .internal => |x| {
             const code = x.getSectionData(self.n_sect);

--- a/src/MachO/Atom.zig
+++ b/src/MachO/Atom.zig
@@ -38,7 +38,10 @@ unwind_records: Loc = .{},
 flags: Flags = .{},
 
 pub fn getName(self: Atom, macho_file: *MachO) [:0]const u8 {
-    return self.getFile(macho_file).object.getString(self.name);
+    return switch (self.getFile(macho_file)) {
+        .dylib => unreachable,
+        inline else => |x| x.getString(self.name),
+    };
 }
 
 pub fn getFile(self: Atom, macho_file: *MachO) File {

--- a/src/MachO/DwarfInfo.zig
+++ b/src/MachO/DwarfInfo.zig
@@ -21,6 +21,7 @@ pub fn deinit(dw: *DwarfInfo, allocator: Allocator) void {
     }
     dw.compile_units.deinit(allocator);
     dw.strtab.deinit(allocator);
+    dw.di_data.deinit(allocator);
 }
 
 fn appendDiData(dw: *DwarfInfo, allocator: Allocator, values: []const u8) error{OutOfMemory}!u32 {

--- a/src/MachO/DwarfInfo.zig
+++ b/src/MachO/DwarfInfo.zig
@@ -1,39 +1,45 @@
-debug_info: []const u8,
-debug_abbrev: []const u8,
-debug_str: []const u8,
-
 /// Abbreviation table indexed by offset in the .debug_abbrev bytestream
 abbrev_tables: std.AutoArrayHashMapUnmanaged(u64, AbbrevTable) = .{},
 /// List of compile units as they appear in the .debug_info bytestream
 compile_units: std.ArrayListUnmanaged(CompileUnit) = .{},
+/// Debug info string table
+strtab: std.ArrayListUnmanaged(u8) = .{},
+/// Debug info data
+di_data: std.ArrayListUnmanaged(u8) = .{},
 
-pub fn init(dw: *DwarfInfo, allocator: Allocator) !void {
-    try dw.parseAbbrevTables(allocator);
-    try dw.parseCompileUnits(allocator);
+pub fn init(dw: *DwarfInfo, allocator: Allocator, di: DebugInfo) !void {
+    try dw.strtab.ensureTotalCapacityPrecise(allocator, di.debug_str.len);
+    dw.strtab.appendSliceAssumeCapacity(di.debug_str);
+    try dw.parseAbbrevTables(allocator, di);
+    try dw.parseCompileUnits(allocator, di);
 }
 
 pub fn deinit(dw: *DwarfInfo, allocator: Allocator) void {
-    allocator.free(dw.debug_info);
-    allocator.free(dw.debug_abbrev);
-    allocator.free(dw.debug_str);
-
     dw.abbrev_tables.deinit(allocator);
     for (dw.compile_units.items) |*cu| {
         cu.deinit(allocator);
     }
     dw.compile_units.deinit(allocator);
+    dw.strtab.deinit(allocator);
+}
+
+fn appendDiData(dw: *DwarfInfo, allocator: Allocator, values: []const u8) error{OutOfMemory}!u32 {
+    const index: u32 = @intCast(dw.di_data.items.len);
+    try dw.di_data.ensureUnusedCapacity(allocator, values.len);
+    dw.di_data.appendSliceAssumeCapacity(values);
+    return index;
 }
 
 fn getString(dw: DwarfInfo, off: u64) [:0]const u8 {
-    assert(off < dw.debug_str.len);
-    return mem.sliceTo(@as([*:0]const u8, @ptrCast(dw.debug_str.ptr + off)), 0);
+    assert(off < dw.strtab.items.len);
+    return mem.sliceTo(@as([*:0]const u8, @ptrCast(dw.strtab.items.ptr + off)), 0);
 }
 
-fn parseAbbrevTables(dw: *DwarfInfo, allocator: Allocator) !void {
+fn parseAbbrevTables(dw: *DwarfInfo, allocator: Allocator, di: DebugInfo) !void {
     const tracy = trace(@src());
     defer tracy.end();
 
-    const debug_abbrev = dw.debug_abbrev;
+    const debug_abbrev = di.debug_abbrev;
     var stream = std.io.fixedBufferStream(debug_abbrev);
     var creader = std.io.countingReader(stream.reader());
     const reader = creader.reader();
@@ -81,11 +87,11 @@ fn parseAbbrevTables(dw: *DwarfInfo, allocator: Allocator) !void {
     }
 }
 
-fn parseCompileUnits(dw: *DwarfInfo, allocator: Allocator) !void {
+fn parseCompileUnits(dw: *DwarfInfo, allocator: Allocator, di: DebugInfo) !void {
     const tracy = trace(@src());
     defer tracy.end();
 
-    const debug_info = dw.debug_info;
+    const debug_info = di.debug_info;
     var stream = std.io.fixedBufferStream(debug_info);
     var creader = std.io.countingReader(stream.reader());
     const reader = creader.reader();
@@ -111,7 +117,7 @@ fn parseCompileUnits(dw: *DwarfInfo, allocator: Allocator) !void {
         cu.header.address_size = try reader.readInt(u8, .little);
 
         const table = dw.abbrev_tables.get(cu.header.debug_abbrev_offset).?;
-        try dw.parseDie(allocator, cu, table, null, &creader);
+        try dw.parseDie(allocator, cu, table, di, null, &creader);
     }
 }
 
@@ -120,6 +126,7 @@ fn parseDie(
     allocator: Allocator,
     cu: *CompileUnit,
     table: AbbrevTable,
+    di: DebugInfo,
     parent: ?u32,
     creader: anytype,
 ) anyerror!void {
@@ -144,19 +151,20 @@ fn parseDie(
         }
 
         const decl = table.decls.get(code) orelse return error.MalformedDwarf; // TODO better errors
-        const data = dw.debug_info;
+        const data = di.debug_info;
         try cu.diePtr(die).values.ensureTotalCapacityPrecise(allocator, decl.attrs.values().len);
 
         for (decl.attrs.values()) |attr| {
             const start = creader.bytes_read;
             try advanceByFormSize(cu, attr.form, creader);
             const end = creader.bytes_read;
-            cu.diePtr(die).values.appendAssumeCapacity(data[start..end]);
+            const index = try dw.appendDiData(allocator, data[start..end]);
+            cu.diePtr(die).values.appendAssumeCapacity(.{ .index = index, .len = @intCast(end - start) });
         }
 
         if (decl.children) {
             // Open scope
-            try dw.parseDie(allocator, cu, table, die, creader);
+            try dw.parseDie(allocator, cu, table, di, die, creader);
         }
     }
 }
@@ -342,7 +350,7 @@ pub const CompileUnit = struct {
 
 pub const Die = struct {
     code: Code,
-    values: std.ArrayListUnmanaged([]const u8) = .{},
+    values: std.ArrayListUnmanaged(struct { index: u32, len: u32 }) = .{},
     children: std.ArrayListUnmanaged(Die.Index) = .{},
 
     pub fn deinit(die: *Die, gpa: Allocator) void {
@@ -356,7 +364,7 @@ pub const Die = struct {
         const index = decl.attrs.getIndex(at) orelse return null;
         const attr = decl.attrs.values()[index];
         const value = die.values.items[index];
-        return .{ .attr = attr, .bytes = value };
+        return .{ .attr = attr, .bytes = ctx.di_data.items[value.index..][0..value.len] };
     }
 
     pub const Index = u32;
@@ -457,6 +465,12 @@ pub const DieValue = struct {
 pub const Format = enum {
     dwarf32,
     dwarf64,
+};
+
+const DebugInfo = struct {
+    debug_info: []const u8,
+    debug_abbrev: []const u8,
+    debug_str: []const u8,
 };
 
 const assert = std.debug.assert;

--- a/src/MachO/DwarfInfo.zig
+++ b/src/MachO/DwarfInfo.zig
@@ -13,6 +13,10 @@ pub fn init(dw: *DwarfInfo, allocator: Allocator) !void {
 }
 
 pub fn deinit(dw: *DwarfInfo, allocator: Allocator) void {
+    allocator.free(dw.debug_info);
+    allocator.free(dw.debug_abbrev);
+    allocator.free(dw.debug_str);
+
     dw.abbrev_tables.deinit(allocator);
     for (dw.compile_units.items) |*cu| {
         cu.deinit(allocator);

--- a/src/MachO/Dylib.zig
+++ b/src/MachO/Dylib.zig
@@ -1,5 +1,4 @@
 path: []const u8,
-data: []const u8,
 index: File.Index,
 
 header: ?macho.mach_header_64 = null,
@@ -32,54 +31,77 @@ pub fn deinit(self: *Dylib, allocator: Allocator) void {
         id.deinit(allocator);
     }
     self.dependents.deinit(allocator);
+    for (self.rpaths.keys()) |rpath| {
+        allocator.free(rpath);
+    }
     self.rpaths.deinit(allocator);
 }
 
-pub fn parse(self: *Dylib, macho_file: *MachO) !void {
+pub fn parse(self: *Dylib, macho_file: *MachO, file: std.fs.File, fat_arch: ?fat.Arch) !void {
     const tracy = trace(@src());
     defer tracy.end();
 
     const gpa = macho_file.base.allocator;
-    var stream = std.io.fixedBufferStream(self.data);
-    const reader = stream.reader();
+    const offset = if (fat_arch) |ar| ar.offset else 0;
 
     log.debug("parsing dylib from binary", .{});
 
-    self.header = try reader.readStruct(macho.mach_header_64);
+    self.header = try file.reader().readStruct(macho.mach_header_64);
 
-    const lc_id = self.getLoadCommand(.ID_DYLIB) orelse {
-        macho_file.base.fatal("{s}: missing LC_ID_DYLIB load command", .{self.path});
-        return error.ParseFailed;
-    };
-    self.id = try Id.fromLoadCommand(gpa, lc_id.cast(macho.dylib_command).?, lc_id.getDylibPathName());
+    const lc_buffer = try gpa.alloc(u8, self.header.?.sizeofcmds);
+    defer gpa.free(lc_buffer);
+    {
+        const amt = try file.preadAll(lc_buffer, offset + @sizeOf(macho.mach_header_64));
+        if (amt != lc_buffer.len) return error.InputOutput;
+    }
 
     var it = LoadCommandIterator{
         .ncmds = self.header.?.ncmds,
-        .buffer = self.data[@sizeOf(macho.mach_header_64)..][0..self.header.?.sizeofcmds],
+        .buffer = lc_buffer,
     };
-    while (it.next()) |cmd| switch (cmd.cmd()) {
+    while (it.next()) |lc| switch (lc.cmd()) {
+        .ID_DYLIB => {
+            self.id = try Id.fromLoadCommand(gpa, lc.cast(macho.dylib_command).?, lc.getDylibPathName());
+        },
         .REEXPORT_DYLIB => if (self.header.?.flags & macho.MH_NO_REEXPORTED_DYLIBS == 0) {
-            const id = try Id.fromLoadCommand(gpa, cmd.cast(macho.dylib_command).?, cmd.getDylibPathName());
+            const id = try Id.fromLoadCommand(gpa, lc.cast(macho.dylib_command).?, lc.getDylibPathName());
             try self.dependents.append(gpa, id);
         },
         .DYLD_INFO_ONLY => {
-            const dyld_cmd = cmd.cast(macho.dyld_info_command).?;
-            const data = self.data[dyld_cmd.export_off..][0..dyld_cmd.export_size];
+            const dyld_cmd = lc.cast(macho.dyld_info_command).?;
+            const data = try gpa.alloc(u8, dyld_cmd.export_size);
+            defer gpa.free(data);
+            const amt = try file.preadAll(data, dyld_cmd.export_off + offset);
+            if (amt != data.len) return error.InputOutput;
             try self.parseTrie(data, macho_file);
         },
         .DYLD_EXPORTS_TRIE => {
-            const ld_cmd = cmd.cast(macho.linkedit_data_command).?;
-            const data = self.data[ld_cmd.dataoff..][0..ld_cmd.datasize];
+            const ld_cmd = lc.cast(macho.linkedit_data_command).?;
+            const data = try gpa.alloc(u8, ld_cmd.datasize);
+            defer gpa.free(data);
+            const amt = try file.preadAll(data, ld_cmd.dataoff + offset);
+            if (amt != data.len) return error.InputOutput;
             try self.parseTrie(data, macho_file);
         },
         .RPATH => {
-            const path = cmd.getRpathPathName();
-            try self.rpaths.put(gpa, path, {});
+            const path = lc.getRpathPathName();
+            try self.rpaths.put(gpa, try gpa.dupe(u8, path), {});
+        },
+        .BUILD_VERSION,
+        .VERSION_MIN_MACOSX,
+        .VERSION_MIN_IPHONEOS,
+        .VERSION_MIN_TVOS,
+        .VERSION_MIN_WATCHOS,
+        => {
+            self.platform = MachO.Options.Platform.fromLoadCommand(lc);
         },
         else => {},
     };
 
-    self.initPlatform();
+    if (self.id == null) {
+        macho_file.base.fatal("{s}: missing LC_ID_DYLIB load command", .{self.path});
+        return error.ParseFailed;
+    }
 }
 
 const TrieIterator = struct {
@@ -547,16 +569,6 @@ pub fn writeSymtab(self: Dylib, macho_file: *MachO) void {
 
 pub inline fn getUmbrella(self: Dylib, macho_file: *MachO) *Dylib {
     return macho_file.getFile(self.umbrella).?.dylib;
-}
-
-fn getLoadCommand(self: Dylib, lc: macho.LC) ?LoadCommandIterator.LoadCommand {
-    var it = LoadCommandIterator{
-        .ncmds = self.header.?.ncmds,
-        .buffer = self.data[@sizeOf(macho.mach_header_64)..][0..self.header.?.sizeofcmds],
-    };
-    while (it.next()) |cmd| {
-        if (cmd.cmd() == lc) return cmd;
-    } else return null;
 }
 
 fn insertString(self: *Dylib, allocator: Allocator, name: []const u8) !u32 {

--- a/src/MachO/Dylib.zig
+++ b/src/MachO/Dylib.zig
@@ -484,8 +484,10 @@ pub fn resetGlobals(self: *Dylib, macho_file: *MachO) void {
     for (self.symbols.items) |sym_index| {
         const sym = macho_file.getSymbol(sym_index);
         const name = sym.name;
+        const global = sym.flags.global;
         sym.* = .{};
         sym.name = name;
+        sym.flags.global = global;
     }
 }
 

--- a/src/MachO/Dylib.zig
+++ b/src/MachO/Dylib.zig
@@ -150,7 +150,7 @@ const TrieIterator = struct {
 
 pub fn addExport(self: *Dylib, allocator: Allocator, name: []const u8, flags: Export.Flags) !void {
     try self.exports.append(allocator, .{
-        .name = try self.insertString(allocator, name),
+        .name = try self.addString(allocator, name),
         .flags = flags,
     });
 }
@@ -557,7 +557,7 @@ pub inline fn getUmbrella(self: Dylib, macho_file: *MachO) *Dylib {
     return macho_file.getFile(self.umbrella).?.dylib;
 }
 
-fn insertString(self: *Dylib, allocator: Allocator, name: []const u8) !u32 {
+fn addString(self: *Dylib, allocator: Allocator, name: []const u8) !u32 {
     const off = @as(u32, @intCast(self.strtab.items.len));
     try self.strtab.writer(allocator).print("{s}\x00", .{name});
     return off;

--- a/src/MachO/InternalObject.zig
+++ b/src/MachO/InternalObject.zig
@@ -27,6 +27,7 @@ pub fn addSymbol(self: *InternalObject, name: [:0]const u8, macho_file: *MachO) 
     self.symbols.addOneAssumeCapacity().* = gop.index;
     const sym = macho_file.getSymbol(gop.index);
     sym.* = .{ .name = off, .file = self.index };
+    sym.flags.global = true;
     return gop.index;
 }
 

--- a/src/MachO/InternalObject.zig
+++ b/src/MachO/InternalObject.zig
@@ -29,6 +29,10 @@ pub fn addSymbol(self: *InternalObject, name: [:0]const u8, macho_file: *MachO) 
     self.symbols.addOneAssumeCapacity().* = gop.index;
     const sym = macho_file.getSymbol(gop.index);
     sym.file = self.index;
+    sym.value = 0;
+    sym.atom = 0;
+    sym.nlist_idx = 0;
+    sym.flags = .{ .global = true };
     return gop.index;
 }
 

--- a/src/MachO/InternalObject.zig
+++ b/src/MachO/InternalObject.zig
@@ -28,8 +28,7 @@ pub fn addSymbol(self: *InternalObject, name: [:0]const u8, macho_file: *MachO) 
     const gop = try macho_file.getOrCreateGlobal(off);
     self.symbols.addOneAssumeCapacity().* = gop.index;
     const sym = macho_file.getSymbol(gop.index);
-    sym.* = .{ .name = off, .file = self.index };
-    sym.flags.global = true;
+    sym.file = self.index;
     return gop.index;
 }
 

--- a/src/MachO/Object.zig
+++ b/src/MachO/Object.zig
@@ -75,10 +75,8 @@ pub fn parse(self: *Object, macho_file: *MachO) !void {
 
     self.header = try reader.readStruct(macho.mach_header_64);
 
-    const lc_data = try gpa.alloc(u8, self.header.?.sizeofcmds);
+    const lc_data = try self.preadAllAlloc(gpa, offset + @sizeOf(macho.mach_header_64), self.header.?.sizeofcmds);
     defer gpa.free(lc_data);
-    var amt = try self.file.preadAll(lc_data, @sizeOf(macho.mach_header_64) + offset);
-    if (amt != lc_data.len) return error.InputOutput;
 
     var it = LoadCommandIterator{
         .ncmds = self.header.?.ncmds,
@@ -102,13 +100,9 @@ pub fn parse(self: *Object, macho_file: *MachO) !void {
         .SYMTAB => {
             const cmd = lc.cast(macho.symtab_command).?;
             try self.strtab.resize(gpa, cmd.strsize);
-            amt = try self.file.preadAll(self.strtab.items, cmd.stroff + offset);
-            if (amt != cmd.strsize) return error.InputOutput;
-
-            const symtab_buffer = try gpa.alloc(u8, cmd.nsyms * @sizeOf(macho.nlist_64));
+            try self.preadAll(self.strtab.items, cmd.stroff + offset);
+            const symtab_buffer = try self.preadAllAlloc(gpa, cmd.symoff + offset, cmd.nsyms * @sizeOf(macho.nlist_64));
             defer gpa.free(symtab_buffer);
-            amt = try self.file.preadAll(symtab_buffer, cmd.symoff + offset);
-            if (amt != symtab_buffer.len) return error.InputOutput;
             const symtab = @as([*]align(1) const macho.nlist_64, @ptrCast(symtab_buffer.ptr))[0..cmd.nsyms];
             try self.symtab.ensureUnusedCapacity(gpa, symtab.len);
             for (symtab) |nlist| {
@@ -121,10 +115,8 @@ pub fn parse(self: *Object, macho_file: *MachO) !void {
         },
         .DATA_IN_CODE => {
             const cmd = lc.cast(macho.linkedit_data_command).?;
-            const buffer = try gpa.alloc(u8, cmd.datasize);
+            const buffer = try self.preadAllAlloc(gpa, offset + cmd.dataoff, cmd.datasize);
             defer gpa.free(buffer);
-            amt = try self.file.preadAll(buffer, offset + cmd.dataoff);
-            if (amt != cmd.datasize) return error.InputOutput;
             const ndice = @divExact(cmd.datasize, @sizeOf(macho.data_in_code_entry));
             const dice = @as([*]align(1) const macho.data_in_code_entry, @ptrCast(buffer.ptr))[0..ndice];
             try self.data_in_code.appendUnalignedSlice(gpa, dice);
@@ -1509,15 +1501,15 @@ pub fn writeStabs(self: *const Object, macho_file: *MachO) void {
     }
 }
 
-pub fn getData(self: *const Object, off: usize, buf: []u8) !void {
+pub fn preadAll(self: *const Object, buf: []u8, off: usize) !void {
     const amt = try self.file.preadAll(buf, off);
     if (amt != buf.len) return error.InputOutput;
 }
 
-pub fn getDataAlloc(self: *const Object, allocator: Allocator, off: usize, size: usize) ![]u8 {
+pub fn preadAllAlloc(self: *const Object, allocator: Allocator, off: usize, size: usize) ![]u8 {
     const buffer = try allocator.alloc(u8, size);
     errdefer allocator.free(buffer);
-    try self.getData(off, buffer);
+    try self.preadAll(buffer, off);
     return buffer;
 }
 
@@ -1526,7 +1518,7 @@ pub fn getSectionData(self: *const Object, allocator: Allocator, index: u32) ![]
     assert(index < slice.items(.header).len);
     const sect = slice.items(.header)[index];
     const offset = if (self.archive) |ar| ar.offset else 0;
-    return self.getDataAlloc(allocator, sect.offset + offset, sect.size);
+    return self.preadAllAlloc(allocator, sect.offset + offset, sect.size);
 }
 
 fn getString(self: Object, off: u32) [:0]const u8 {
@@ -1790,11 +1782,9 @@ const x86_64 = struct {
     ) !void {
         const gpa = macho_file.base.allocator;
 
-        const relocs_buffer = try gpa.alloc(u8, sect.nreloc * @sizeOf(macho.relocation_info));
-        defer gpa.free(relocs_buffer);
         const offset = if (self.archive) |ar| ar.offset else 0;
-        const amt = try self.file.preadAll(relocs_buffer, offset + sect.reloff);
-        if (amt != relocs_buffer.len) return error.InputOutput;
+        const relocs_buffer = try self.preadAllAlloc(gpa, sect.reloff + offset, sect.nreloc * @sizeOf(macho.relocation_info));
+        defer gpa.free(relocs_buffer);
 
         const relocs = @as([*]align(1) const macho.relocation_info, @ptrCast(relocs_buffer.ptr))[0..sect.nreloc];
 
@@ -1947,11 +1937,9 @@ const aarch64 = struct {
     ) !void {
         const gpa = macho_file.base.allocator;
 
-        const relocs_buffer = try gpa.alloc(u8, sect.nreloc * @sizeOf(macho.relocation_info));
-        defer gpa.free(relocs_buffer);
         const offset = if (self.archive) |ar| ar.offset else 0;
-        const amt = try self.file.preadAll(relocs_buffer, offset + sect.reloff);
-        if (amt != relocs_buffer.len) return error.InputOutput;
+        const relocs_buffer = try self.preadAllAlloc(gpa, sect.reloff + offset, sect.nreloc * @sizeOf(macho.relocation_info));
+        defer gpa.free(relocs_buffer);
 
         const relocs = @as([*]align(1) const macho.relocation_info, @ptrCast(relocs_buffer.ptr))[0..sect.nreloc];
 

--- a/src/MachO/Object.zig
+++ b/src/MachO/Object.zig
@@ -975,7 +975,7 @@ fn initDwarfInfo(self: *Object, macho_file: *MachO) !void {
     var dwarf_info = DwarfInfo{
         .debug_info = try self.getSectionData(gpa, @intCast(debug_info_index.?)),
         .debug_abbrev = try self.getSectionData(gpa, @intCast(debug_abbrev_index.?)),
-        .debug_str = if (debug_str_index) |index| try self.getSectionData(gpa, @intCast(index)) else "",
+        .debug_str = if (debug_str_index) |index| try self.getSectionData(gpa, @intCast(index)) else &[0]u8{},
     };
     errdefer dwarf_info.deinit(gpa);
     dwarf_info.init(gpa) catch {

--- a/src/MachO/Symbol.zig
+++ b/src/MachO/Symbol.zig
@@ -57,8 +57,8 @@ pub fn weakRef(symbol: Symbol, macho_file: *MachO) bool {
 pub fn getName(symbol: Symbol, macho_file: *MachO) [:0]const u8 {
     if (symbol.flags.global) return macho_file.string_intern.getAssumeExists(symbol.name);
     return switch (symbol.getFile(macho_file).?) {
-        .object => |x| x.getString(symbol.name),
-        else => macho_file.string_intern.getAssumeExists(symbol.name),
+        .dylib => unreachable, // There are no local symbols for dylibs
+        inline else => |x| x.getString(symbol.name),
     };
 }
 

--- a/src/MachO/Symbol.zig
+++ b/src/MachO/Symbol.zig
@@ -55,7 +55,11 @@ pub fn weakRef(symbol: Symbol, macho_file: *MachO) bool {
 }
 
 pub fn getName(symbol: Symbol, macho_file: *MachO) [:0]const u8 {
-    return macho_file.string_intern.getAssumeExists(symbol.name);
+    if (symbol.flags.global) return macho_file.string_intern.getAssumeExists(symbol.name);
+    return switch (symbol.getFile(macho_file).?) {
+        .object => |x| x.getString(symbol.name),
+        else => macho_file.string_intern.getAssumeExists(symbol.name),
+    };
 }
 
 pub fn getAtom(symbol: Symbol, macho_file: *MachO) ?*Atom {
@@ -314,6 +318,11 @@ pub const Flags = packed struct {
 
     /// Whether the symbol is exported at runtime.
     @"export": bool = false,
+
+    /// Whether the symbol is effectively an extern and takes part in global
+    /// symbol resolution. Then, its name will be saved in global string interning
+    /// table.
+    global: bool = false,
 
     /// Whether this symbol is weak.
     weak: bool = false,

--- a/src/MachO/relocatable.zig
+++ b/src/MachO/relocatable.zig
@@ -238,9 +238,7 @@ fn writeAtoms(macho_file: *MachO) !void {
             const atom = macho_file.getAtom(atom_index).?;
             assert(atom.flags.alive);
             const off = atom.value - header.addr;
-            const in_code = try atom.getCode(macho_file);
-            defer gpa.free(in_code);
-            @memcpy(code[off..][0..atom.size], in_code);
+            try atom.getCode(macho_file, code[off..][0..atom.size]);
             try atom.writeRelocs(macho_file, code[off..][0..atom.size], &relocs);
         }
 

--- a/src/MachO/relocatable.zig
+++ b/src/MachO/relocatable.zig
@@ -238,7 +238,9 @@ fn writeAtoms(macho_file: *MachO) !void {
             const atom = macho_file.getAtom(atom_index).?;
             assert(atom.flags.alive);
             const off = atom.value - header.addr;
-            @memcpy(code[off..][0..atom.size], atom.getCode(macho_file));
+            const in_code = try atom.getCode(macho_file);
+            defer gpa.free(in_code);
+            @memcpy(code[off..][0..atom.size], in_code);
             try atom.writeRelocs(macho_file, code[off..][0..atom.size], &relocs);
         }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -2,12 +2,18 @@ const std = @import("std");
 const builtin = @import("builtin");
 const build_options = @import("build_options");
 const mem = std.mem;
+const tracy = @import("tracy.zig");
 
 const Allocator = mem.Allocator;
 const ThreadPool = std.Thread.Pool;
 const Zld = @import("Zld.zig");
 
-const gpa = std.heap.c_allocator;
+var tracy_alloc = tracy.tracyAllocator(std.heap.c_allocator);
+
+const gpa = if (tracy.enable_allocation)
+    tracy_alloc.allocator()
+else
+    std.heap.c_allocator;
 
 const usage =
     \\zld is a generic linker driver.

--- a/src/tracy.zig
+++ b/src/tracy.zig
@@ -7,7 +7,7 @@ pub const enable_allocation = enable;
 pub const enable_callstack = enable;
 
 // TODO: make this configurable
-const callstack_depth = 10;
+const callstack_depth = build_options.tracy_callstack_depth;
 
 const ___tracy_c_zone_context = extern struct {
     id: u32,
@@ -60,7 +60,7 @@ pub const Ctx = if (enable) ___tracy_c_zone_context else struct {
     }
 };
 
-pub inline fn trace(comptime src: std.builtin.SourceLocation) Ctx {
+pub fn trace(comptime src: std.builtin.SourceLocation) Ctx {
     if (!enable) return .{};
 
     const global = struct {


### PR DESCRIPTION
Memory reduced to 1444.9MB from 2757.87MB according to Tracy.

Linker performance virtually unchanged:

```
$ hyperfine ./zld ./zld_old
Benchmark 1: ./zld
  Time (mean ± σ):      4.351 s ±  0.027 s    [User: 3.547 s, System: 2.467 s]
  Range (min … max):    4.308 s …  4.401 s    10 runs

Benchmark 2: ./zld_old
  Time (mean ± σ):      4.345 s ±  0.020 s    [User: 3.844 s, System: 2.106 s]
  Range (min … max):    4.319 s …  4.381 s    10 runs

Summary
  ./zld_old ran
    1.00 ± 0.01 times faster than ./zld
```