### PR TITLE
macho: make input object file descriptors short-lived

### DIFF
--- a/src/MachO/Archive.zig
+++ b/src/MachO/Archive.zig
@@ -116,7 +116,6 @@ pub fn parse(self: *Archive, macho_file: *MachO, path: []const u8, file: std.fs.
                 .offset = offset + pos,
             },
             .path = name,
-            .file = try std.fs.cwd().openFile(path, .{}),
             .index = undefined,
             .alive = false,
             .mtime = hdr.date() catch 0,

--- a/src/MachO/Object.zig
+++ b/src/MachO/Object.zig
@@ -185,6 +185,14 @@ pub fn parse(self: *Object, file: std.fs.File, macho_file: *MachO) !void {
     try self.sortAtoms(macho_file);
     try self.initSymbols(macho_file);
     try self.initSymbolStabs(nlists.items, macho_file);
+}
+
+pub fn initData(self: *Object, file: std.fs.File, macho_file: *MachO) !void {
+    const tracy = trace(@src());
+    defer tracy.end();
+
+    log.debug("initializing data in  object file {}", .{self.fmtPath()});
+
     try self.initSectionData(file, macho_file);
     try self.initRelocs(file, macho_file);
 
@@ -200,7 +208,7 @@ pub fn parse(self: *Object, file: std.fs.File, macho_file: *MachO) !void {
         try self.parseUnwindRecords(macho_file);
     }
 
-    try self.initDataInCode(gpa, file);
+    try self.initDataInCode(macho_file.base.allocator, file);
     try self.initDwarfInfo(macho_file);
 
     for (self.atoms.items) |atom_index| {

--- a/src/MachO/eh_frame.zig
+++ b/src/MachO/eh_frame.zig
@@ -63,7 +63,8 @@ pub const Cie = struct {
 
     pub fn getData(cie: Cie, macho_file: *MachO) []const u8 {
         const object = cie.getObject(macho_file);
-        return object.eh_frame_data.items[cie.offset..][0..cie.getSize()];
+        const data = object.sections.items(.data)[object.eh_frame_sect_index.?].items;
+        return data[cie.offset..][0..cie.getSize()];
     }
 
     pub fn getPersonality(cie: Cie, macho_file: *MachO) ?*Symbol {
@@ -215,7 +216,8 @@ pub const Fde = struct {
 
     pub fn getData(fde: Fde, macho_file: *MachO) []const u8 {
         const object = fde.getObject(macho_file);
-        return object.eh_frame_data.items[fde.offset..][0..fde.getSize()];
+        const data = object.sections.items(.data)[object.eh_frame_sect_index.?].items;
+        return data[fde.offset..][0..fde.getSize()];
     }
 
     pub fn getCie(fde: Fde, macho_file: *MachO) *const Cie {

--- a/src/MachO/relocatable.zig
+++ b/src/MachO/relocatable.zig
@@ -236,7 +236,7 @@ fn writeAtoms(macho_file: *MachO) !void {
             const atom = macho_file.getAtom(atom_index).?;
             assert(atom.flags.alive);
             const off = atom.value;
-            try atom.getCode(macho_file, code[off..][0..atom.size]);
+            try atom.getData(macho_file, code[off..][0..atom.size]);
             try atom.writeRelocs(macho_file, code[off..][0..atom.size], &relocs);
         }
 


### PR DESCRIPTION
This avoids issue described in ziglang/zig#18827

Incidentally improves time performance:

```
Benchmark 1: ./zld
  Time (mean ± σ):      5.896 s ±  0.031 s    [User: 4.228 s, System: 2.626 s]
  Range (min … max):    5.849 s …  5.950 s    10 runs

Benchmark 2: ./zld_old
  Time (mean ± σ):      7.126 s ±  0.260 s    [User: 4.854 s, System: 3.238 s]
  Range (min … max):    6.954 s …  7.632 s    10 runs

Summary
  ./zld ran
    1.21 ± 0.04 times faster than ./zld_old
```

at the cost of somewhat increased memory pressure: at 1459MB up from 1156MB.

I think this tradeoff is worth it, but happy to hear opinions.

EDIT: measurements taken on Intel MBP running macOS 13.6 with 8-core i9@2.3GHz and 32GB RAM.

EDIT2: On M1Pro MBP with 32GB RAM, 1466MB up from 1192MB, while benchmarks are:

```
Benchmark 1: ./zld
  Time (mean ± σ):      2.559 s ±  0.008 s    [User: 2.580 s, System: 0.778 s]
  Range (min … max):    2.548 s …  2.574 s    10 runs

Benchmark 2: ./zld_old
  Time (mean ± σ):      3.064 s ±  0.007 s    [User: 2.792 s, System: 1.067 s]
  Range (min … max):    3.050 s …  3.077 s    10 runs

Summary
  ./zld ran
    1.20 ± 0.00 times faster than ./zld_old
```