### PR TITLE
macho: report special symbols if undefined

### DIFF
--- a/src/MachO/Atom.zig
+++ b/src/MachO/Atom.zig
@@ -308,9 +308,9 @@ fn reportUndefSymbol(self: Atom, rel: Relocation, macho_file: *MachO) !bool {
         const gpa = macho_file.base.allocator;
         const gop = try macho_file.undefs.getOrPut(gpa, file.getGlobals()[rel.target]);
         if (!gop.found_existing) {
-            gop.value_ptr.* = .{};
+            gop.value_ptr.* = .{ .refs = .{} };
         }
-        try gop.value_ptr.append(gpa, .{ .index = self.atom_index, .file = self.file });
+        try gop.value_ptr.refs.append(gpa, .{ .index = self.atom_index, .file = self.file });
         return true;
     }
 

--- a/src/MachO/InternalObject.zig
+++ b/src/MachO/InternalObject.zig
@@ -507,6 +507,42 @@ pub fn scanRelocs(self: *InternalObject, macho_file: *MachO) void {
     }
 }
 
+pub fn checkUndefs(self: InternalObject, macho_file: *MachO) !void {
+    const addUndef = struct {
+        fn addUndef(mf: *MachO, index: MachO.SymbolResolver.Index, tag: anytype) !void {
+            const gpa = mf.base.allocator;
+            mf.undefs_mutex.lock();
+            defer mf.undefs_mutex.unlock();
+            const gop = try mf.undefs.getOrPut(gpa, index);
+            if (!gop.found_existing) {
+                gop.value_ptr.* = tag;
+            }
+        }
+    }.addUndef;
+
+    for (self.force_undefined.items) |index| {
+        const ref = self.getSymbolRef(index, macho_file);
+        if (ref.getFile(macho_file) == null) {
+            try addUndef(macho_file, self.globals.items[index], .force_undefined);
+        }
+    }
+    if (self.getEntryRef(macho_file)) |ref| {
+        if (ref.getFile(macho_file) == null) {
+            try addUndef(macho_file, self.globals.items[self.entry_index.?], .entry);
+        }
+    }
+    if (self.getDyldStubBinderRef(macho_file)) |ref| {
+        if (ref.getFile(macho_file) == null and macho_file.stubs.symbols.items.len > 0) {
+            try addUndef(macho_file, self.globals.items[self.dyld_stub_binder_index.?], .dyld_stub_binder);
+        }
+    }
+    if (self.getObjcMsgSendRef(macho_file)) |ref| {
+        if (ref.getFile(macho_file) == null and self.needsObjcMsgsendSymbol()) {
+            try addUndef(macho_file, self.globals.items[self.objc_msg_send_index.?], .objc_msgsend);
+        }
+    }
+}
+
 pub fn allocateSyntheticSymbols(self: *InternalObject, macho_file: *MachO) void {
     const text_seg = macho_file.getTextSegment();
 
@@ -785,6 +821,13 @@ pub fn setSymbolExtra(self: *InternalObject, index: u32, extra: Symbol.Extra) vo
             else => @compileError("bad field type"),
         };
     }
+}
+
+fn needsObjcMsgsendSymbol(self: InternalObject) bool {
+    for (self.sections.items(.extra)) |extra| {
+        if (extra.is_objc_methname or extra.is_objc_selref) return true;
+    }
+    return false;
 }
 
 const FormatContext = struct {


### PR DESCRIPTION
Special symbols include explictly force undefined symbols passed via -u flag, missing entry point symbol, missing 'dyld_stub_binder' symbol, or missing '_objc_msgsend' symbol.